### PR TITLE
feat: add initial backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+# Build
+FROM golang:1.21.1-alpine AS builder
+
+WORKDIR /build
+COPY . ./backend
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+# GOARCH is automatically detected from the environment i.e. the build image.
+
+RUN go build -C ./backend -o ../zeevision ./cmd/zeevision/main.go
+
+# Install
+FROM alpine:3.18
+
+WORKDIR /app
+COPY --from=builder /build/zeevision /usr/bin/zeevision
+
+CMD ["zeevision"]


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#96 

### Description
<!-- Please add what is included in this pull request. -->
Initial Dockerfile for containerization of the backend.

### Testing
<!-- How can code reviewers test this PR? -->
Follow these steps to build and run the containerized application:

```bash
# Change to backend dir
$ cd backend
# Build the image
$ docker build -t zeevision:latest .
# Start the container
$ docker run --rm -it zeevision
Hello world!
```

As shown above, running the container should print "Hello world!"