### PR TITLE
ci: add code formatting check for Go files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Check formatting of Go files
-        run: >
+        run: |
           test -z "$UNFORMATTED_FILES" || {
             echo "$UNFORMATTED_FILES" | while read -r filename
             do


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#87 

### Description
<!-- Please add what is included in this pull request. -->
Added a pipeline stage which validates that Go files are correctly formatted according to `go fmt` tool.

### Testing
<!-- How can code reviewers test this PR? -->
See [commits](https://github.com/ducanhpham0312/zeevision/pull/33/commits). Pipeline fails for unformatted code (d85c427) but passes after formatting (da42e14).
