### PR TITLE
Add docker compose to backend and a frontend recommendation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,14 @@
-version: '3'
+version: "3"
 
 services:
   backend:
     build:
-      context: backend/
-      dockerfile: Dockerfile  
-    image: zeevision-backend:latest  
-    container_name: zeevision-backend
-    ports:
-      - "8080:8080"
+      context: "backend/"
+      dockerfile: "Dockerfile"
+    image: "zeevision-backend:latest"  
+    container_name: "zeevision-backend"
     networks:
       - zeevision_network
-#  frontend:
-#    build:
-#      context: frontend/zeevision/
-#      dockerfile: Dockerfile
-#    image: zeevision-frontend:latest
-#    container_name: zeevision-frontend
-#    ports:
-#      - "3000:3000"
-#    networks:
-#      - zeevision_network
 
 networks:
   zeevision_network:


### PR DESCRIPTION
### Linked issue
Closes ducanhpham0312/zeevision-private#97 


### Description
Adds docker compose. backend is enabled and a frontend stub is not enabled, but there as a recommendation.


### Testing
docker compose up, executed in repository root
