### PR TITLE
chore(backend): cache backend dependencies in container image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,18 +2,23 @@
 FROM golang:1.21.1-alpine AS builder
 
 WORKDIR /build
-COPY . ./backend
+
+# Download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 # GOARCH is automatically detected from the environment i.e. the build image.
 
-RUN go build -C ./backend -o ../zeevision ./cmd/zeevision/main.go
+# Build
+COPY . ./
+RUN go build -o ../zeevision ./cmd/zeevision/main.go
 
 # Install
 FROM alpine:3.18
 
 WORKDIR /app
-COPY --from=builder /build/zeevision /usr/bin/zeevision
+COPY --from=builder /zeevision /usr/bin/zeevision
 
 CMD ["zeevision"]


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#53 

### Description
<!-- Please add what is included in this pull request. -->
Modified the backend `Dockerfile` to download dependencies in separate step before building. This enables the image layer to be cached when dependencies haven't changed enabling faster builds, both locally and in CI.

### Testing
<!-- How can code reviewers test this PR? -->
1. Build the `backend/` container.
2. Edit code in `backend/cmd/zeevision/main.go`. For example, add a comment.
3. Rebuild the container. It should show that dependencies are cached: `=> CACHED [builder 4/6] RUN go mod download`, even though the application was rebuilt: `=> [builder 6/6] RUN go build -o ../zeevision ./cmd/zeevision/main.go`