### PR TITLE
ci(backend): replace native build with docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,35 +12,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-            cgo-enabled: 0
-          - goos: darwin
-            goarch: amd64
-            cgo-enabled: 1
-          - goos: darwin
-            goarch: arm64
-            cgo-enabled: 1
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      CGO_ENABLED: ${{ matrix.cgo-enabled }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21.x"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Build
-        run: go build -C ./backend -v ./cmd/zeevision/main.go
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
   format-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#45 

### Description
<!-- Please add what is included in this pull request. -->
Build Docker container image in CI pipeline. This replaces native builds on separate architectures and operating systems with Linux based container on `amd64` and `arm64` platforms.

### Testing
<!-- How can code reviewers test this PR? -->
See the CI run for this PR.