### PR TITLE
HOTFIX: frontend dockerfile build fails

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 EXPOSE 5173
 
 # Define the command to start development server 
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "dev" , "--", "--host"]


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Finish the issue that resolves #42


### Description
<!-- Please add what is included in this pull request. -->
Currently the Dockerfile is broken in master. This fix is based on PR #42 comment that is yet to taken into account.

### Testing
<!-- How can code reviewers test this PR? -->
Please check that the image can be build and the container can be started properly. I haven't been able to build the image because I'm on the train and the internet is shit :D

```
# Change to frontend dir
$ cd frontend
# Build the image
$ docker build -t zeevision:latest .
# Start the container
$ docker run --rm -it zeevision
```

After that the frontend should be up and running at port 5173.