### PR TITLE
chore: remove ci run filtering

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -5,8 +5,6 @@ name: Backend
 on:
   push:
     branches: ["master"]
-    paths-ignore:
-      - "frontend/**"
   pull_request:
     branches: ["master"]
   schedule:
@@ -49,7 +47,6 @@ jobs:
           platforms: linux/arm64
 
   lint:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/configuration.yml
+++ b/.github/workflows/configuration.yml
@@ -14,7 +14,6 @@ concurrency:
 
 jobs:
   yaml-lint:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -5,8 +5,6 @@ name: Frontend
 on:
   push:
     branches: ["master"]
-    paths-ignore:
-      - 'backend/**'
   pull_request:
     branches: ["master"]
 
@@ -37,7 +35,6 @@ jobs:
           npm run build
 
   lint:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%


### PR DESCRIPTION
### Description
<!-- Please add what is included in this pull request. -->
The repository is now public, so we don't need to be worried about ci minutes anymore. Plus, looks like codecov might get some issues with filtering ci runs. This PR removes all such filterings.

### Testing
<!-- How can code reviewers test this PR? -->
- Explanatory. No test needed.