### PR TITLE
fix(ci): disable test caching

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.21.x"
+          cache: false
 
       - name: Run tests coverage
         working-directory: ./backend


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
No linked issue

### Description
<!-- Please add what is included in this pull request. -->
Backend test pipeline produces a warning related to caching:

![image](https://github.com/ducanhpham0312/zeevision/assets/11910622/6c0d5a0d-67a2-4011-88d6-da8eeafaffa8)

This commit fixes it by disabling caching from this pipeline. I tried enabling caching, but that wouldn't work straight away.

### Testing
<!-- How can code reviewers test this PR? -->
See pipeline run for Backend and see that the warning doesn't exists anymore.