### PR TITLE
chore(backend): upgrade chi library

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.40
 	github.com/IBM/sarama v1.42.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/go-chi/chi v1.5.5
+	github.com/go-chi/chi/v5 v5.0.10
 	github.com/gorilla/websocket v1.5.1
 	github.com/mandrigin/gin-spa v0.0.0-20200212133200-790d0c0c7335
 	github.com/rs/cors v1.10.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -38,8 +38,8 @@ github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2 h1:dyuNlYlG1faym
 github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2/go.mod h1:iqneQ2Df3omzIVTkIfn7c1acsVnMGiSLn4XF5Blh3Yg=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
-github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
-github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/backend/internal/endpoint/endpoint.go
+++ b/backend/internal/endpoint/endpoint.go
@@ -8,7 +8,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/ducanhpham0312/zeevision/backend/internal/environment"
 	"github.com/gin-gonic/gin"
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/mandrigin/gin-spa/spa"
 	"github.com/rs/cors"
 	"golang.org/x/sync/errgroup"

--- a/backend/internal/endpoint/endpoint.go
+++ b/backend/internal/endpoint/endpoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/internal/environment"
 	"github.com/gin-gonic/gin"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/mandrigin/gin-spa/spa"
 	"github.com/rs/cors"
 	"golang.org/x/sync/errgroup"
@@ -114,6 +115,8 @@ func NewAppServer(conf Config) (*http.Server, error) {
 // Create a new API server.
 func NewAPIServer(conf Config) (*http.Server, error) {
 	router := chi.NewRouter()
+	router.Use(middleware.Logger)
+	router.Use(middleware.Recoverer)
 
 	// Allow CORS from the specified origins.
 	router.Use(cors.New(cors.Options{


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
No linked issue.

### Description
<!-- Please add what is included in this pull request. -->
Dependabot PR #196 previously tried to upgrade the `chi` package, but there exists a newer package using go modules. This PR manually upgrades to the newest `chi` package since dependabot wasn't able to automatically upgrade it.

I also added logger and recoverer middleware to the `chi` router since that is now available similar to `go-gin` library, although this change doesn't strictly belong to this PR.

### Testing
<!-- How can code reviewers test this PR? -->
No functional changes, so pipeline run should be enough.