### PR TITLE
feat: instance fetch api

### DIFF
--- a/backend/cmd/zeevision/main.go
+++ b/backend/cmd/zeevision/main.go
@@ -31,7 +31,7 @@ func main() {
 		panic(err)
 	}
 
-	err = storage.CreateProcessTable(db)
+	err = storage.AutoMigrate(db)
 	if err != nil {
 		panic(err)
 	}

--- a/backend/graph/dummy.go
+++ b/backend/graph/dummy.go
@@ -2,7 +2,7 @@ package graph
 
 import "github.com/ducanhpham0312/zeevision/backend/graph/model"
 
-var dummyInstances = []*model.Instance{
+var DummyInstances = []*model.Instance{
 	{
 		//nolint:gomnd
 		InstanceKey:   12345,

--- a/backend/graph/dummy.go
+++ b/backend/graph/dummy.go
@@ -5,23 +5,20 @@ import "github.com/ducanhpham0312/zeevision/backend/graph/model"
 var DummyInstances = []*model.Instance{
 	{
 		//nolint:gomnd
-		InstanceKey:   12345,
-		BpmnProcessID: "multi-instance-process",
-		Status:        "Active",
-		StartTime:     "2023-01-02T00:00:00Z",
+		InstanceKey: 12345,
+		Status:      "Active",
+		StartTime:   "2023-01-02T00:00:00Z",
 	},
 	{
 		//nolint:gomnd
-		InstanceKey:   54321,
-		BpmnProcessID: "money-loan",
-		Status:        "Completed",
-		StartTime:     "2023-01-01T00:15:00Z",
+		InstanceKey: 54321,
+		Status:      "Completed",
+		StartTime:   "2023-01-01T00:15:00Z",
 	},
 	{
 		//nolint:gomnd
-		InstanceKey:   55555,
-		BpmnProcessID: "order-main",
-		Status:        "Completed",
-		StartTime:     "2023-01-08T00:15:00Z",
+		InstanceKey: 55555,
+		Status:      "Completed",
+		StartTime:   "2023-01-08T00:15:00Z",
 	},
 }

--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -39,6 +39,7 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Instance() InstanceResolver
 	Process() ProcessResolver
 	Query() QueryResolver
 }
@@ -94,7 +95,12 @@ type ComplexityRoot struct {
 	}
 }
 
+type InstanceResolver interface {
+	BpmnResource(ctx context.Context, obj *model.Instance) (string, error)
+}
 type ProcessResolver interface {
+	BpmnResource(ctx context.Context, obj *model.Process) (string, error)
+
 	Instances(ctx context.Context, obj *model.Process) ([]*model.Instance, error)
 	MessageSubscriptions(ctx context.Context, obj *model.Process) ([]*model.MessageSubscription, error)
 
@@ -588,50 +594,6 @@ func (ec *executionContext) fieldContext_Instance_bpmnLiveStatus(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Instance_bpmnResource(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Instance_bpmnResource(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnResource, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Instance_bpmnResource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Instance",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Instance_startTime(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Instance_startTime(ctx, field)
 	if err != nil {
@@ -671,6 +633,50 @@ func (ec *executionContext) fieldContext_Instance_startTime(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type DateTime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Instance_bpmnResource(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_bpmnResource(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Instance().BpmnResource(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_bpmnResource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -1174,7 +1180,7 @@ func (ec *executionContext) _Process_bpmnResource(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnResource, nil
+		return ec.resolvers.Process().BpmnResource(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -1192,6 +1198,50 @@ func (ec *executionContext) _Process_bpmnResource(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_Process_bpmnResource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_bpmnProcessId(ctx context.Context, field graphql.CollectedField, obj *model.Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_bpmnProcessId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BpmnProcessID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_bpmnProcessId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Process",
 		Field:      field,
@@ -1289,10 +1339,10 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 			switch field.Name {
 			case "bpmnLiveStatus":
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "bpmnResource":
+				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "bpmnProcessId":
 				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
@@ -1357,50 +1407,6 @@ func (ec *executionContext) fieldContext_Process_messageSubscriptions(ctx contex
 				return ec.fieldContext_MessageSubscription_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type MessageSubscription", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Process_bpmnProcessId(ctx context.Context, field graphql.CollectedField, obj *model.Process) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Process_bpmnProcessId(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnProcessID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Process_bpmnProcessId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Process",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -1597,14 +1603,14 @@ func (ec *executionContext) fieldContext_Query_processes(ctx context.Context, fi
 				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
 			case "bpmnResource":
 				return ec.fieldContext_Process_bpmnResource(ctx, field)
+			case "bpmnProcessId":
+				return ec.fieldContext_Process_bpmnProcessId(ctx, field)
 			case "deploymentTime":
 				return ec.fieldContext_Process_deploymentTime(ctx, field)
 			case "instances":
 				return ec.fieldContext_Process_instances(ctx, field)
 			case "messageSubscriptions":
 				return ec.fieldContext_Process_messageSubscriptions(ctx, field)
-			case "bpmnProcessId":
-				return ec.fieldContext_Process_bpmnProcessId(ctx, field)
 			case "processKey":
 				return ec.fieldContext_Process_processKey(ctx, field)
 			case "timers":
@@ -1662,14 +1668,14 @@ func (ec *executionContext) fieldContext_Query_process(ctx context.Context, fiel
 				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
 			case "bpmnResource":
 				return ec.fieldContext_Process_bpmnResource(ctx, field)
+			case "bpmnProcessId":
+				return ec.fieldContext_Process_bpmnProcessId(ctx, field)
 			case "deploymentTime":
 				return ec.fieldContext_Process_deploymentTime(ctx, field)
 			case "instances":
 				return ec.fieldContext_Process_instances(ctx, field)
 			case "messageSubscriptions":
 				return ec.fieldContext_Process_messageSubscriptions(ctx, field)
-			case "bpmnProcessId":
-				return ec.fieldContext_Process_bpmnProcessId(ctx, field)
 			case "processKey":
 				return ec.fieldContext_Process_processKey(ctx, field)
 			case "timers":
@@ -1735,10 +1741,10 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 			switch field.Name {
 			case "bpmnLiveStatus":
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "bpmnResource":
+				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "bpmnProcessId":
 				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
@@ -1792,10 +1798,10 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 			switch field.Name {
 			case "bpmnLiveStatus":
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "bpmnResource":
+				return ec.fieldContext_Instance_bpmnResource(ctx, field)
 			case "bpmnProcessId":
 				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
@@ -3966,37 +3972,68 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 		case "bpmnLiveStatus":
 			out.Values[i] = ec._Instance_bpmnLiveStatus(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "bpmnResource":
-			out.Values[i] = ec._Instance_bpmnResource(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "startTime":
 			out.Values[i] = ec._Instance_startTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "bpmnResource":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Instance_bpmnResource(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "bpmnProcessId":
 			out.Values[i] = ec._Instance_bpmnProcessId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "instanceKey":
 			out.Values[i] = ec._Instance_instanceKey(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "version":
 			out.Values[i] = ec._Instance_version(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "status":
 			out.Values[i] = ec._Instance_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -4102,7 +4139,43 @@ func (ec *executionContext) _Process(ctx context.Context, sel ast.SelectionSet, 
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "bpmnResource":
-			out.Values[i] = ec._Process_bpmnResource(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_bpmnResource(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "bpmnProcessId":
+			out.Values[i] = ec._Process_bpmnProcessId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -4183,11 +4256,6 @@ func (ec *executionContext) _Process(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "bpmnProcessId":
-			out.Values[i] = ec._Process_bpmnProcessId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "processKey":
 			out.Values[i] = ec._Process_processKey(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -50,9 +50,9 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 	Instance struct {
 		BpmnLiveStatus func(childComplexity int) int
-		BpmnProcessID  func(childComplexity int) int
-		BpmnResource   func(childComplexity int) int
 		InstanceKey    func(childComplexity int) int
+		Process        func(childComplexity int) int
+		ProcessKey     func(childComplexity int) int
 		StartTime      func(childComplexity int) int
 		Status         func(childComplexity int) int
 		Version        func(childComplexity int) int
@@ -96,7 +96,7 @@ type ComplexityRoot struct {
 }
 
 type InstanceResolver interface {
-	BpmnResource(ctx context.Context, obj *model.Instance) (string, error)
+	Process(ctx context.Context, obj *model.Instance) (*model.Process, error)
 }
 type ProcessResolver interface {
 	BpmnResource(ctx context.Context, obj *model.Process) (string, error)
@@ -139,26 +139,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Instance.BpmnLiveStatus(childComplexity), true
 
-	case "Instance.bpmnProcessId":
-		if e.complexity.Instance.BpmnProcessID == nil {
-			break
-		}
-
-		return e.complexity.Instance.BpmnProcessID(childComplexity), true
-
-	case "Instance.bpmnResource":
-		if e.complexity.Instance.BpmnResource == nil {
-			break
-		}
-
-		return e.complexity.Instance.BpmnResource(childComplexity), true
-
 	case "Instance.instanceKey":
 		if e.complexity.Instance.InstanceKey == nil {
 			break
 		}
 
 		return e.complexity.Instance.InstanceKey(childComplexity), true
+
+	case "Instance.process":
+		if e.complexity.Instance.Process == nil {
+			break
+		}
+
+		return e.complexity.Instance.Process(childComplexity), true
+
+	case "Instance.processKey":
+		if e.complexity.Instance.ProcessKey == nil {
+			break
+		}
+
+		return e.complexity.Instance.ProcessKey(childComplexity), true
 
 	case "Instance.startTime":
 		if e.complexity.Instance.StartTime == nil {
@@ -638,94 +638,6 @@ func (ec *executionContext) fieldContext_Instance_startTime(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Instance_bpmnResource(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Instance_bpmnResource(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Instance().BpmnResource(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Instance_bpmnResource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Instance",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Instance_bpmnProcessId(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Instance_bpmnProcessId(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnProcessID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Instance_bpmnProcessId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Instance",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Instance_instanceKey(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Instance_instanceKey(ctx, field)
 	if err != nil {
@@ -758,6 +670,50 @@ func (ec *executionContext) _Instance_instanceKey(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_Instance_instanceKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Instance_processKey(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_processKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProcessKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_processKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Instance",
 		Field:      field,
@@ -853,6 +809,74 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Instance_process(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_process(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Instance().Process(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Process)
+	fc.Result = res
+	return ec.marshalNProcess2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐProcess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_process(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "activeInstances":
+				return ec.fieldContext_Process_activeInstances(ctx, field)
+			case "completedInstances":
+				return ec.fieldContext_Process_completedInstances(ctx, field)
+			case "bpmnLiveStatus":
+				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
+			case "bpmnResource":
+				return ec.fieldContext_Process_bpmnResource(ctx, field)
+			case "bpmnProcessId":
+				return ec.fieldContext_Process_bpmnProcessId(ctx, field)
+			case "deploymentTime":
+				return ec.fieldContext_Process_deploymentTime(ctx, field)
+			case "instances":
+				return ec.fieldContext_Process_instances(ctx, field)
+			case "messageSubscriptions":
+				return ec.fieldContext_Process_messageSubscriptions(ctx, field)
+			case "processKey":
+				return ec.fieldContext_Process_processKey(ctx, field)
+			case "timers":
+				return ec.fieldContext_Process_timers(ctx, field)
+			case "version":
+				return ec.fieldContext_Process_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
 		},
 	}
 	return fc, nil
@@ -1341,16 +1365,16 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
-			case "bpmnProcessId":
-				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
+			case "processKey":
+				return ec.fieldContext_Instance_processKey(ctx, field)
 			case "version":
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "process":
+				return ec.fieldContext_Instance_process(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Instance", field.Name)
 		},
@@ -1743,16 +1767,16 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
-			case "bpmnProcessId":
-				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
+			case "processKey":
+				return ec.fieldContext_Instance_processKey(ctx, field)
 			case "version":
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "process":
+				return ec.fieldContext_Instance_process(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Instance", field.Name)
 		},
@@ -1800,16 +1824,16 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
-			case "bpmnResource":
-				return ec.fieldContext_Instance_bpmnResource(ctx, field)
-			case "bpmnProcessId":
-				return ec.fieldContext_Instance_bpmnProcessId(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
+			case "processKey":
+				return ec.fieldContext_Instance_processKey(ctx, field)
 			case "version":
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "process":
+				return ec.fieldContext_Instance_process(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Instance", field.Name)
 		},
@@ -3979,7 +4003,27 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "bpmnResource":
+		case "instanceKey":
+			out.Values[i] = ec._Instance_instanceKey(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "processKey":
+			out.Values[i] = ec._Instance_processKey(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "version":
+			out.Values[i] = ec._Instance_version(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "status":
+			out.Values[i] = ec._Instance_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "process":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -3988,7 +4032,7 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Instance_bpmnResource(ctx, field, obj)
+				res = ec._Instance_process(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -4015,26 +4059,6 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "bpmnProcessId":
-			out.Values[i] = ec._Instance_bpmnProcessId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "instanceKey":
-			out.Values[i] = ec._Instance_instanceKey(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "version":
-			out.Values[i] = ec._Instance_version(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "status":
-			out.Values[i] = ec._Instance_status(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4993,6 +5017,10 @@ func (ec *executionContext) marshalNMessageSubscription2ᚖgithubᚗcomᚋducanh
 		return graphql.Null
 	}
 	return ec._MessageSubscription(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNProcess2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐProcess(ctx context.Context, sel ast.SelectionSet, v model.Process) graphql.Marshaler {
+	return ec._Process(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNProcess2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐProcessᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Process) graphql.Marshaler {

--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -834,9 +834,9 @@ func (ec *executionContext) _Instance_status(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(model.Status)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -846,7 +846,7 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Status does not have child fields")
 		},
 	}
 	return fc, nil
@@ -1010,9 +1010,9 @@ func (ec *executionContext) _MessageSubscription_status(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(model.Status)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_MessageSubscription_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1022,7 +1022,7 @@ func (ec *executionContext) fieldContext_MessageSubscription_status(ctx context.
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Status does not have child fields")
 		},
 	}
 	return fc, nil
@@ -2153,9 +2153,9 @@ func (ec *executionContext) _Timer_status(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(model.Status)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Timer_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2165,7 +2165,7 @@ func (ec *executionContext) fieldContext_Timer_status(ctx context.Context, field
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Status does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4979,6 +4979,16 @@ func (ec *executionContext) marshalNProcess2ᚖgithubᚗcomᚋducanhpham0312ᚋz
 		return graphql.Null
 	}
 	return ec._Process(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx context.Context, v interface{}) (model.Status, error) {
+	var res model.Status
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx context.Context, sel ast.SelectionSet, v model.Status) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -38,7 +38,7 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
 		InstanceKey:    instance.ProcessInstanceKey,
 		ProcessKey:     instance.ProcessDefinitionKey,
-		Version:        1, // TODO
+		Version:        instance.Version,
 		Status:         status,
 		// Process has its own resolver and is not populated here.
 	}

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ducanhpham0312/zeevision/backend/internal/storage"
@@ -19,6 +20,17 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 }
 
 func FromStorageInstance(instance storage.Instance) *Instance {
+	var status Status
+	switch instance.Status {
+	case "Active":
+		status = StatusActive
+	case "Completed":
+		status = StatusCompleted
+	default:
+		// Panic will be caught by the GraphQL server as internal server error.
+		panic(fmt.Sprintf("model: unknown instance status: %s", instance.Status))
+	}
+
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
 		BpmnResource:   "", // TODO
@@ -26,7 +38,7 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 		BpmnProcessID:  instance.BpmnProcessID,
 		InstanceKey:    instance.ProcessInstanceKey,
 		Version:        1, // TODO
-		Status:         instance.Status,
+		Status:         status,
 	}
 }
 

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -21,14 +21,9 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 
 func FromStorageInstance(instance storage.Instance) *Instance {
 	var status Status
-	switch instance.Status {
-	case "Active":
-		status = StatusActive
-	case "Completed":
-		status = StatusCompleted
-	default:
+	if err := status.UnmarshalGQL(instance.Status); err != nil {
 		// Panic will be caught by the GraphQL server as internal server error.
-		panic(fmt.Sprintf("model: unknown instance status: %s", instance.Status))
+		panic(fmt.Errorf("unmarshal storage instance: %w", err))
 	}
 
 	return &Instance{

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"time"
+
+	"github.com/ducanhpham0312/zeevision/backend/internal/storage"
+)
+
+// Convert slice of values T to slice of values U by applying function f.
+//
+// TODO: replace with stdlib equivalent once, if ever, available.
+func Map[T, U any](slice []T, f func(T) U) []U {
+	result := make([]U, 0, len(slice))
+	for _, item := range slice {
+		result = append(result, f(item))
+	}
+
+	return result
+}
+
+func FromStorageInstance(instance storage.Instance) *Instance {
+	return &Instance{
+		BpmnLiveStatus: "", // TODO
+		BpmnResource:   "", // TODO
+		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
+		BpmnProcessID:  instance.BpmnProcessID,
+		InstanceKey:    instance.ProcessInstanceKey,
+		Version:        1, // TODO
+		Status:         instance.Status,
+	}
+}
+
+func FromStorageProcess(process storage.Process) *Process {
+	return &Process{
+		ActiveInstances:    0,  // TODO
+		CompletedInstances: 0,  // TODO
+		BpmnLiveStatus:     "", // TODO
+		BpmnResource:       process.BpmnResource,
+		DeploymentTime:     time.Now().UTC().Format(time.RFC3339), // TODO
+		BpmnProcessID:      process.BpmnProcessID,
+		ProcessKey:         process.ProcessDefinitionKey,
+		Version:            process.Version,
+		// Instances, MessageSubscriptions, and Timers have their
+		// own resolvers and are not populated here.
+	}
+}

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -19,6 +19,10 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 	return result
 }
 
+func FromStorageBpmnResource(resource storage.BpmnResource) string {
+	return resource.BpmnFile
+}
+
 // Convert storage instance to GraphQL instance.
 func FromStorageInstance(instance storage.Instance) *Instance {
 	var status Status
@@ -29,12 +33,12 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
-		BpmnResource:   "", // TODO
-		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
 		BpmnProcessID:  instance.BpmnProcessID,
+		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
 		InstanceKey:    instance.ProcessInstanceKey,
 		Version:        1, // TODO
 		Status:         status,
+		// BpmnResource has its own resolver and is not populated here.
 	}
 }
 
@@ -44,12 +48,11 @@ func FromStorageProcess(process storage.Process) *Process {
 		ActiveInstances:    0,  // TODO
 		CompletedInstances: 0,  // TODO
 		BpmnLiveStatus:     "", // TODO
-		BpmnResource:       process.BpmnResource,
-		DeploymentTime:     process.DeploymentTime.UTC().Format(time.RFC3339),
 		BpmnProcessID:      process.BpmnProcessID,
+		DeploymentTime:     process.DeploymentTime.UTC().Format(time.RFC3339),
 		ProcessKey:         process.ProcessDefinitionKey,
 		Version:            process.Version,
-		// Instances, MessageSubscriptions, and Timers have their
+		// Instances, MessageSubscriptions, Timers, BpmnResource have their
 		// own resolvers and are not populated here.
 	}
 }

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -19,6 +19,7 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 	return result
 }
 
+// Convert storage instance to GraphQL instance.
 func FromStorageInstance(instance storage.Instance) *Instance {
 	var status Status
 	if err := status.UnmarshalGQL(instance.Status); err != nil {
@@ -37,6 +38,7 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 	}
 }
 
+// Convert storage process to GraphQL process.
 func FromStorageProcess(process storage.Process) *Process {
 	return &Process{
 		ActiveInstances:    0,  // TODO

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -45,7 +45,7 @@ func FromStorageProcess(process storage.Process) *Process {
 		CompletedInstances: 0,  // TODO
 		BpmnLiveStatus:     "", // TODO
 		BpmnResource:       process.BpmnResource,
-		DeploymentTime:     time.Now().UTC().Format(time.RFC3339), // TODO
+		DeploymentTime:     process.DeploymentTime.UTC().Format(time.RFC3339),
 		BpmnProcessID:      process.BpmnProcessID,
 		ProcessKey:         process.ProcessDefinitionKey,
 		Version:            process.Version,

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -19,8 +19,10 @@ func Map[T, U any](slice []T, f func(T) U) []U {
 	return result
 }
 
-func FromStorageBpmnResource(resource storage.BpmnResource) string {
-	return resource.BpmnFile
+// Convert storage bpmn resource to GraphQL bpmn resource containing the
+// base64 encoded BPMN XML file.
+func FromStorageBpmnResource(bpmnResource storage.BpmnResource) string {
+	return bpmnResource.BpmnFile
 }
 
 // Convert storage instance to GraphQL instance.
@@ -33,12 +35,12 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
-		BpmnProcessID:  instance.BpmnProcessID,
 		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
 		InstanceKey:    instance.ProcessInstanceKey,
+		ProcessKey:     instance.ProcessDefinitionKey,
 		Version:        1, // TODO
 		Status:         status,
-		// BpmnResource has its own resolver and is not populated here.
+		// Process has its own resolver and is not populated here.
 	}
 }
 

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -19,6 +19,17 @@ func TestMap(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestFromStorageBpmnResource(t *testing.T) {
+	storageResource := storage.BpmnResource{
+		BpmnProcessID: "main-loop",
+		BpmnFile:      "test",
+	}
+	expected := "test"
+
+	actual := FromStorageBpmnResource(storageResource)
+	assert.Equal(t, expected, actual)
+}
+
 func TestFromStorageInstance(t *testing.T) {
 	now := time.Now()
 

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -34,14 +34,12 @@ func TestFromStorageInstance(t *testing.T) {
 				ProcessDefinitionKey: 1,
 				Status:               "ACTIVE",
 				StartTime:            now,
-				BpmnProcessID:        "main-loop",
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
-				BpmnProcessID:  "main-loop",
-				BpmnResource:   "",
 				InstanceKey:    10,
+				ProcessKey:     1,
 				Version:        1, // TODO
 				Status:         StatusActive,
 			},
@@ -53,14 +51,12 @@ func TestFromStorageInstance(t *testing.T) {
 				ProcessDefinitionKey: 2,
 				Status:               "COMPLETED",
 				StartTime:            now,
-				BpmnProcessID:        "main-loop",
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
-				BpmnProcessID:  "main-loop",
-				BpmnResource:   "",
 				InstanceKey:    20,
+				ProcessKey:     2,
 				Version:        1, // TODO
 				Status:         StatusCompleted,
 			},
@@ -71,12 +67,7 @@ func TestFromStorageInstance(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := FromStorageInstance(test.storageInstance)
 
-			assert.Equal(t, test.expected.InstanceKey, actual.InstanceKey)
-			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
-			assert.Equal(t, test.expected.Status, actual.Status)
-			assert.Equal(t, test.expected.StartTime, actual.StartTime)
-			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)
-			assert.Equal(t, test.expected.Version, actual.Version)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -89,10 +80,7 @@ func TestInvalidStatus(t *testing.T) {
 	}()
 
 	storageInstance := storage.Instance{
-		ProcessInstanceKey:   10,
-		ProcessDefinitionKey: 1,
-		Status:               "InvalidStatus",
-		StartTime:            time.Now(),
+		Status: "InvalidStatus",
 	}
 
 	// Should panic.
@@ -114,6 +102,11 @@ func TestFromStorageProcess(t *testing.T) {
 				Version:              1,
 				DeploymentTime:       now,
 				BpmnProcessID:        "main-loop",
+				// BpmnResource should not transfer to model.Instance.
+				BpmnResource: storage.BpmnResource{
+					BpmnProcessID: "main-loop",
+					BpmnFile:      "test",
+				},
 				// Instances should not transfer to model.Instance.
 				Instances: []storage.Instance{
 					{
@@ -121,22 +114,18 @@ func TestFromStorageProcess(t *testing.T) {
 						ProcessDefinitionKey: 1,
 						Status:               "Active",
 						StartTime:            now,
-						BpmnProcessID:        "main-loop",
 					},
 				},
 			},
 			expected: &Process{
-				ActiveInstances:      0,  // TODO
-				CompletedInstances:   0,  // TODO
-				BpmnLiveStatus:       "", // TODO
-				DeploymentTime:       now.UTC().Format(time.RFC3339),
-				BpmnProcessID:        "main-loop",
-				BpmnResource:         "",
-				ProcessKey:           1,
-				Version:              1,
-				Instances:            []*Instance{},
-				MessageSubscriptions: []*MessageSubscription{},
-				Timers:               []*Timer{},
+				ActiveInstances:    0,  // TODO
+				CompletedInstances: 0,  // TODO
+				BpmnLiveStatus:     "", // TODO
+				DeploymentTime:     now.UTC().Format(time.RFC3339),
+				BpmnProcessID:      "main-loop",
+				BpmnResource:       "",
+				ProcessKey:         1,
+				Version:            1,
 			},
 		},
 		{
@@ -146,20 +135,23 @@ func TestFromStorageProcess(t *testing.T) {
 				Version:              1,
 				DeploymentTime:       now,
 				BpmnProcessID:        "main-loop",
-				Instances:            []storage.Instance{},
+				// BpmnResource should not transfer to model.Instance.
+				BpmnResource: storage.BpmnResource{
+					BpmnProcessID: "main-loop",
+					BpmnFile:      "test",
+				},
+				// Instances should not transfer to model.Instance.
+				Instances: []storage.Instance{},
 			},
 			expected: &Process{
-				ActiveInstances:      0,  // TODO
-				CompletedInstances:   0,  // TODO
-				BpmnLiveStatus:       "", // TODO
-				DeploymentTime:       now.UTC().Format(time.RFC3339),
-				BpmnProcessID:        "main-loop",
-				BpmnResource:         "",
-				ProcessKey:           2,
-				Version:              1,
-				Instances:            []*Instance{},
-				MessageSubscriptions: []*MessageSubscription{},
-				Timers:               []*Timer{},
+				ActiveInstances:    0,  // TODO
+				CompletedInstances: 0,  // TODO
+				BpmnLiveStatus:     "", // TODO
+				DeploymentTime:     now.UTC().Format(time.RFC3339),
+				BpmnProcessID:      "main-loop",
+				BpmnResource:       "",
+				ProcessKey:         2,
+				Version:            1,
 			},
 		},
 	}
@@ -168,11 +160,7 @@ func TestFromStorageProcess(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := FromStorageProcess(test.storageProcess)
 
-			assert.Equal(t, test.expected.ProcessKey, actual.ProcessKey)
-			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
-			assert.Equal(t, test.expected.DeploymentTime, actual.DeploymentTime)
-			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)
-			assert.Equal(t, test.expected.Version, actual.Version)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -32,6 +32,7 @@ func TestFromStorageInstance(t *testing.T) {
 			storageInstance: storage.Instance{
 				ProcessInstanceKey:   10,
 				ProcessDefinitionKey: 1,
+				Version:              1,
 				Status:               "ACTIVE",
 				StartTime:            now,
 			},
@@ -40,7 +41,7 @@ func TestFromStorageInstance(t *testing.T) {
 				StartTime:      now.UTC().Format(time.RFC3339),
 				InstanceKey:    10,
 				ProcessKey:     1,
-				Version:        1, // TODO
+				Version:        1,
 				Status:         StatusActive,
 			},
 		},
@@ -49,6 +50,7 @@ func TestFromStorageInstance(t *testing.T) {
 			storageInstance: storage.Instance{
 				ProcessInstanceKey:   20,
 				ProcessDefinitionKey: 2,
+				Version:              2,
 				Status:               "COMPLETED",
 				StartTime:            now,
 			},
@@ -57,7 +59,7 @@ func TestFromStorageInstance(t *testing.T) {
 				StartTime:      now.UTC().Format(time.RFC3339),
 				InstanceKey:    20,
 				ProcessKey:     2,
-				Version:        1, // TODO
+				Version:        2,
 				Status:         StatusCompleted,
 			},
 		},

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -97,6 +97,7 @@ func TestInvalidStatus(t *testing.T) {
 		StartTime:            time.Now(),
 	}
 
+	// Should panic.
 	FromStorageInstance(storageInstance)
 }
 

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -1,0 +1,180 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ducanhpham0312/zeevision/backend/internal/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMap(t *testing.T) {
+	slice := []string{"a", "bb", "ccc"}
+	expected := []int{1, 2, 3}
+
+	actual := Map(slice, func(s string) int {
+		return len(s)
+	})
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFromStorageInstance(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name            string
+		storageInstance storage.Instance
+		expected        *Instance
+	}{
+		{
+			name: "Active instance",
+			storageInstance: storage.Instance{
+				ProcessInstanceKey:   10,
+				BpmnProcessID:        "multi-instance-process",
+				ProcessDefinitionKey: 1,
+				Status:               "ACTIVE",
+				StartTime:            now,
+			},
+			expected: &Instance{
+				BpmnLiveStatus: "", // TODO
+				BpmnResource:   "", // TODO
+				StartTime:      now.UTC().Format(time.RFC3339),
+				BpmnProcessID:  "multi-instance-process",
+				InstanceKey:    10,
+				Version:        1, // TODO
+				Status:         StatusActive,
+			},
+		},
+		{
+			name: "Completed instance",
+			storageInstance: storage.Instance{
+				ProcessInstanceKey:   20,
+				BpmnProcessID:        "money-loan",
+				ProcessDefinitionKey: 2,
+				Status:               "COMPLETED",
+				StartTime:            now,
+			},
+			expected: &Instance{
+				BpmnLiveStatus: "", // TODO
+				BpmnResource:   "", // TODO
+				StartTime:      now.UTC().Format(time.RFC3339),
+				BpmnProcessID:  "money-loan",
+				InstanceKey:    20,
+				Version:        1, // TODO
+				Status:         StatusCompleted,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := FromStorageInstance(test.storageInstance)
+
+			assert.Equal(t, test.expected.InstanceKey, actual.InstanceKey)
+			assert.Equal(t, test.expected.BpmnProcessID, actual.BpmnProcessID)
+			assert.Equal(t, test.expected.Status, actual.Status)
+			assert.Equal(t, test.expected.StartTime, actual.StartTime)
+			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)
+			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
+			assert.Equal(t, test.expected.Version, actual.Version)
+		})
+	}
+}
+
+func TestInvalidStatus(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			assert.Fail(t, "expected panic")
+		}
+	}()
+
+	storageInstance := storage.Instance{
+		ProcessInstanceKey:   10,
+		BpmnProcessID:        "multi-instance-process",
+		ProcessDefinitionKey: 1,
+		Status:               "InvalidStatus",
+		StartTime:            time.Now(),
+	}
+
+	FromStorageInstance(storageInstance)
+}
+
+func TestFromStorageProcess(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name           string
+		storageProcess storage.Process
+		expected       *Process
+	}{
+		{
+			name: "Active instance",
+			storageProcess: storage.Process{
+				ProcessDefinitionKey: 1,
+				BpmnProcessID:        "multi-instance-process",
+				Version:              1,
+				BpmnResource:         "hlasd876/fhd=",
+				// Instances should not transfer to model.Instance.
+				Instances: []storage.Instance{
+					{
+						ProcessInstanceKey:   10,
+						BpmnProcessID:        "multi-instance-process",
+						ProcessDefinitionKey: 1,
+						Status:               "Active",
+						StartTime:            now,
+					},
+				},
+			},
+			expected: &Process{
+				ActiveInstances:      0,  // TODO
+				CompletedInstances:   0,  // TODO
+				BpmnLiveStatus:       "", // TODO
+				BpmnResource:         "hlasd876/fhd=",
+				DeploymentTime:       now.UTC().Format(time.RFC3339),
+				BpmnProcessID:        "multi-instance-process",
+				ProcessKey:           1,
+				Version:              1,
+				Instances:            []*Instance{},
+				MessageSubscriptions: []*MessageSubscription{},
+				Timers:               []*Timer{},
+			},
+		},
+		{
+			name: "Completed instance",
+			storageProcess: storage.Process{
+				ProcessDefinitionKey: 2,
+				BpmnProcessID:        "money-loan",
+				Version:              1,
+				BpmnResource:         "9I79a8s7gKJH",
+				Instances:            []storage.Instance{},
+			},
+			expected: &Process{
+				ActiveInstances:      0,  // TODO
+				CompletedInstances:   0,  // TODO
+				BpmnLiveStatus:       "", // TODO
+				BpmnResource:         "9I79a8s7gKJH",
+				DeploymentTime:       now.UTC().Format(time.RFC3339),
+				BpmnProcessID:        "money-loan",
+				ProcessKey:           2,
+				Version:              1,
+				Instances:            []*Instance{},
+				MessageSubscriptions: []*MessageSubscription{},
+				Timers:               []*Timer{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := FromStorageProcess(test.storageProcess)
+
+			assert.Equal(t, test.expected.ProcessKey, actual.ProcessKey)
+			assert.Equal(t, test.expected.BpmnProcessID, actual.BpmnProcessID)
+			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
+			assert.Equal(t, test.expected.DeploymentTime, actual.DeploymentTime)
+			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)
+			assert.Equal(t, test.expected.Version, actual.Version)
+		})
+	}
+}

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -31,16 +31,16 @@ func TestFromStorageInstance(t *testing.T) {
 			name: "Active instance",
 			storageInstance: storage.Instance{
 				ProcessInstanceKey:   10,
-				BpmnProcessID:        "multi-instance-process",
 				ProcessDefinitionKey: 1,
 				Status:               "ACTIVE",
 				StartTime:            now,
+				BpmnProcessID:        "main-loop",
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
-				BpmnResource:   "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
-				BpmnProcessID:  "multi-instance-process",
+				BpmnProcessID:  "main-loop",
+				BpmnResource:   "",
 				InstanceKey:    10,
 				Version:        1, // TODO
 				Status:         StatusActive,
@@ -50,16 +50,16 @@ func TestFromStorageInstance(t *testing.T) {
 			name: "Completed instance",
 			storageInstance: storage.Instance{
 				ProcessInstanceKey:   20,
-				BpmnProcessID:        "money-loan",
 				ProcessDefinitionKey: 2,
 				Status:               "COMPLETED",
 				StartTime:            now,
+				BpmnProcessID:        "main-loop",
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
-				BpmnResource:   "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
-				BpmnProcessID:  "money-loan",
+				BpmnProcessID:  "main-loop",
+				BpmnResource:   "",
 				InstanceKey:    20,
 				Version:        1, // TODO
 				Status:         StatusCompleted,
@@ -72,11 +72,10 @@ func TestFromStorageInstance(t *testing.T) {
 			actual := FromStorageInstance(test.storageInstance)
 
 			assert.Equal(t, test.expected.InstanceKey, actual.InstanceKey)
-			assert.Equal(t, test.expected.BpmnProcessID, actual.BpmnProcessID)
+			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
 			assert.Equal(t, test.expected.Status, actual.Status)
 			assert.Equal(t, test.expected.StartTime, actual.StartTime)
 			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)
-			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
 			assert.Equal(t, test.expected.Version, actual.Version)
 		})
 	}
@@ -91,7 +90,6 @@ func TestInvalidStatus(t *testing.T) {
 
 	storageInstance := storage.Instance{
 		ProcessInstanceKey:   10,
-		BpmnProcessID:        "multi-instance-process",
 		ProcessDefinitionKey: 1,
 		Status:               "InvalidStatus",
 		StartTime:            time.Now(),
@@ -113,18 +111,17 @@ func TestFromStorageProcess(t *testing.T) {
 			name: "Active instance",
 			storageProcess: storage.Process{
 				ProcessDefinitionKey: 1,
-				BpmnProcessID:        "multi-instance-process",
 				Version:              1,
-				BpmnResource:         "hlasd876/fhd=",
 				DeploymentTime:       now,
+				BpmnProcessID:        "main-loop",
 				// Instances should not transfer to model.Instance.
 				Instances: []storage.Instance{
 					{
 						ProcessInstanceKey:   10,
-						BpmnProcessID:        "multi-instance-process",
 						ProcessDefinitionKey: 1,
 						Status:               "Active",
 						StartTime:            now,
+						BpmnProcessID:        "main-loop",
 					},
 				},
 			},
@@ -132,9 +129,9 @@ func TestFromStorageProcess(t *testing.T) {
 				ActiveInstances:      0,  // TODO
 				CompletedInstances:   0,  // TODO
 				BpmnLiveStatus:       "", // TODO
-				BpmnResource:         "hlasd876/fhd=",
 				DeploymentTime:       now.UTC().Format(time.RFC3339),
-				BpmnProcessID:        "multi-instance-process",
+				BpmnProcessID:        "main-loop",
+				BpmnResource:         "",
 				ProcessKey:           1,
 				Version:              1,
 				Instances:            []*Instance{},
@@ -146,19 +143,18 @@ func TestFromStorageProcess(t *testing.T) {
 			name: "Completed instance",
 			storageProcess: storage.Process{
 				ProcessDefinitionKey: 2,
-				BpmnProcessID:        "money-loan",
 				Version:              1,
-				BpmnResource:         "9I79a8s7gKJH",
 				DeploymentTime:       now,
+				BpmnProcessID:        "main-loop",
 				Instances:            []storage.Instance{},
 			},
 			expected: &Process{
 				ActiveInstances:      0,  // TODO
 				CompletedInstances:   0,  // TODO
 				BpmnLiveStatus:       "", // TODO
-				BpmnResource:         "9I79a8s7gKJH",
 				DeploymentTime:       now.UTC().Format(time.RFC3339),
-				BpmnProcessID:        "money-loan",
+				BpmnProcessID:        "main-loop",
+				BpmnResource:         "",
 				ProcessKey:           2,
 				Version:              1,
 				Instances:            []*Instance{},
@@ -173,7 +169,6 @@ func TestFromStorageProcess(t *testing.T) {
 			actual := FromStorageProcess(test.storageProcess)
 
 			assert.Equal(t, test.expected.ProcessKey, actual.ProcessKey)
-			assert.Equal(t, test.expected.BpmnProcessID, actual.BpmnProcessID)
 			assert.Equal(t, test.expected.BpmnResource, actual.BpmnResource)
 			assert.Equal(t, test.expected.DeploymentTime, actual.DeploymentTime)
 			assert.Equal(t, test.expected.BpmnLiveStatus, actual.BpmnLiveStatus)

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -116,6 +116,7 @@ func TestFromStorageProcess(t *testing.T) {
 				BpmnProcessID:        "multi-instance-process",
 				Version:              1,
 				BpmnResource:         "hlasd876/fhd=",
+				DeploymentTime:       now,
 				// Instances should not transfer to model.Instance.
 				Instances: []storage.Instance{
 					{
@@ -148,6 +149,7 @@ func TestFromStorageProcess(t *testing.T) {
 				BpmnProcessID:        "money-loan",
 				Version:              1,
 				BpmnResource:         "9I79a8s7gKJH",
+				DeploymentTime:       now,
 				Instances:            []storage.Instance{},
 			},
 			expected: &Process{

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -2,6 +2,12 @@
 
 package model
 
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
 type Instance struct {
 	BpmnLiveStatus string `json:"bpmnLiveStatus"`
 	BpmnResource   string `json:"bpmnResource"`
@@ -9,14 +15,14 @@ type Instance struct {
 	BpmnProcessID  string `json:"bpmnProcessId"`
 	InstanceKey    int64  `json:"instanceKey"`
 	Version        int64  `json:"version"`
-	Status         string `json:"status"`
+	Status         Status `json:"status"`
 }
 
 type MessageSubscription struct {
 	CreatedAt   string `json:"createdAt"`
 	ElementID   int64  `json:"elementId"`
 	MessageName string `json:"messageName"`
-	Status      string `json:"status"`
+	Status      Status `json:"status"`
 }
 
 type Process struct {
@@ -38,5 +44,46 @@ type Timer struct {
 	ProcessInstanceKey int64  `json:"processInstanceKey"`
 	Repetitions        string `json:"repetitions"`
 	StartTime          string `json:"startTime"`
-	Status             string `json:"status"`
+	Status             Status `json:"status"`
+}
+
+type Status string
+
+const (
+	StatusActive    Status = "ACTIVE"
+	StatusCompleted Status = "COMPLETED"
+)
+
+var AllStatus = []Status{
+	StatusActive,
+	StatusCompleted,
+}
+
+func (e Status) IsValid() bool {
+	switch e {
+	case StatusActive, StatusCompleted:
+		return true
+	}
+	return false
+}
+
+func (e Status) String() string {
+	return string(e)
+}
+
+func (e *Status) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Status(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Status", str)
+	}
+	return nil
+}
+
+func (e Status) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Instance struct {
-	BpmnLiveStatus string `json:"bpmnLiveStatus"`
-	StartTime      string `json:"startTime"`
-	BpmnResource   string `json:"bpmnResource"`
-	BpmnProcessID  string `json:"bpmnProcessId"`
-	InstanceKey    int64  `json:"instanceKey"`
-	Version        int64  `json:"version"`
-	Status         Status `json:"status"`
+	BpmnLiveStatus string   `json:"bpmnLiveStatus"`
+	StartTime      string   `json:"startTime"`
+	InstanceKey    int64    `json:"instanceKey"`
+	ProcessKey     int64    `json:"processKey"`
+	Version        int64    `json:"version"`
+	Status         Status   `json:"status"`
+	Process        *Process `json:"process"`
 }
 
 type MessageSubscription struct {

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -10,8 +10,8 @@ import (
 
 type Instance struct {
 	BpmnLiveStatus string `json:"bpmnLiveStatus"`
-	BpmnResource   string `json:"bpmnResource"`
 	StartTime      string `json:"startTime"`
+	BpmnResource   string `json:"bpmnResource"`
 	BpmnProcessID  string `json:"bpmnProcessId"`
 	InstanceKey    int64  `json:"instanceKey"`
 	Version        int64  `json:"version"`
@@ -30,10 +30,10 @@ type Process struct {
 	CompletedInstances   int64                  `json:"completedInstances"`
 	BpmnLiveStatus       string                 `json:"bpmnLiveStatus"`
 	BpmnResource         string                 `json:"bpmnResource"`
+	BpmnProcessID        string                 `json:"bpmnProcessId"`
 	DeploymentTime       string                 `json:"deploymentTime"`
 	Instances            []*Instance            `json:"instances"`
 	MessageSubscriptions []*MessageSubscription `json:"messageSubscriptions"`
-	BpmnProcessID        string                 `json:"bpmnProcessId"`
 	ProcessKey           int64                  `json:"processKey"`
 	Timers               []*Timer               `json:"timers"`
 	Version              int64                  `json:"version"`

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -33,11 +33,11 @@ type Process {
 type Instance {
   bpmnLiveStatus: String!
   startTime: DateTime!
-  bpmnResource: String! @goField(forceResolver: true)
-  bpmnProcessId: String!
   instanceKey: Int!
+  processKey: Int!
   version: Int!
   status: Status!
+  process: Process! @goField(forceResolver: true)
 }
 
 type MessageSubscription {

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -20,11 +20,11 @@ type Process {
   activeInstances: Int!
   completedInstances: Int!
   bpmnLiveStatus: String!
-  bpmnResource: String!
+  bpmnResource: String! @goField(forceResolver: true)
+  bpmnProcessId: String!
   deploymentTime: DateTime!
   instances: [Instance!]! @goField(forceResolver: true)
   messageSubscriptions: [MessageSubscription!]! @goField(forceResolver: true)
-  bpmnProcessId: String!
   processKey: Int!
   timers: [Timer!]! @goField(forceResolver: true)
   version: Int!
@@ -32,8 +32,8 @@ type Process {
 
 type Instance {
   bpmnLiveStatus: String!
-  bpmnResource: String!
   startTime: DateTime!
+  bpmnResource: String! @goField(forceResolver: true)
   bpmnProcessId: String!
   instanceKey: Int!
   version: Int!

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -37,14 +37,14 @@ type Instance {
   bpmnProcessId: String!
   instanceKey: Int!
   version: Int!
-  status: String!
+  status: Status!
 }
 
 type MessageSubscription {
   createdAt: DateTime!
   elementId: Int!
   messageName: String!
-  status: String!
+  status: Status!
 }
 
 type Timer {
@@ -52,7 +52,12 @@ type Timer {
   processInstanceKey: Int!
   repetitions: String!
   startTime: DateTime!
-  status: String!
+  status: Status!
+}
+
+enum Status {
+  ACTIVE
+  COMPLETED
 }
 
 # The `DateTime` scalar type represents a date and time following the

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -11,14 +11,14 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/graph/model"
 )
 
-// BpmnResource is the resolver for the bpmnResource field.
-func (r *instanceResolver) BpmnResource(ctx context.Context, obj *model.Instance) (string, error) {
-	dbBpmnResource, err := r.Fetcher.GetBpmnResource(ctx, obj.BpmnProcessID)
+// Process is the resolver for the process field.
+func (r *instanceResolver) Process(ctx context.Context, obj *model.Instance) (*model.Process, error) {
+	dbProcess, err := r.Fetcher.GetProcess(ctx, obj.ProcessKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch bpmn resource: %w", err)
+		return nil, fmt.Errorf("failed to fetch process: %w", err)
 	}
 
-	return model.FromStorageBpmnResource(dbBpmnResource), nil
+	return model.FromStorageProcess(dbProcess), nil
 }
 
 // BpmnResource is the resolver for the bpmnResource field.

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -11,6 +11,26 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/graph/model"
 )
 
+// BpmnResource is the resolver for the bpmnResource field.
+func (r *instanceResolver) BpmnResource(ctx context.Context, obj *model.Instance) (string, error) {
+	dbBpmnResource, err := r.Fetcher.GetBpmnResource(ctx, obj.BpmnProcessID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch bpmn resource: %w", err)
+	}
+
+	return model.FromStorageBpmnResource(dbBpmnResource), nil
+}
+
+// BpmnResource is the resolver for the bpmnResource field.
+func (r *processResolver) BpmnResource(ctx context.Context, obj *model.Process) (string, error) {
+	dbBpmnResource, err := r.Fetcher.GetBpmnResource(ctx, obj.BpmnProcessID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch bpmn resource: %w", err)
+	}
+
+	return model.FromStorageBpmnResource(dbBpmnResource), nil
+}
+
 // Instances is the resolver for the instances field.
 func (r *processResolver) Instances(ctx context.Context, obj *model.Process) ([]*model.Instance, error) {
 	dbInstances, err := r.Fetcher.GetInstancesForProcess(ctx, obj.ProcessKey)
@@ -71,11 +91,15 @@ func (r *queryResolver) Instance(ctx context.Context, instanceKey int64) (*model
 	return model.FromStorageInstance(dbInstance), nil
 }
 
+// Instance returns InstanceResolver implementation.
+func (r *Resolver) Instance() InstanceResolver { return &instanceResolver{r} }
+
 // Process returns ProcessResolver implementation.
 func (r *Resolver) Process() ProcessResolver { return &processResolver{r} }
 
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
+type instanceResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }

--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -12,6 +12,7 @@ import (
 var migrations = []any{
 	&Process{},
 	&Instance{},
+	&BpmnResource{},
 }
 
 // Configuration to connect to database.

--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -8,21 +8,27 @@ import (
 	"gorm.io/gorm"
 )
 
-// Configuration to connect to database
+// List of migrations to be run on database during initialization.
+var migrations = []any{
+	&Process{},
+	&Instance{},
+}
+
+// Configuration to connect to database.
 type DsnConfig struct {
-	// Username used to log in to the database
+	// Username used to log in to the database.
 	User string
-	// Password of the logging in user
+	// Password of the logging in user.
 	Password string
-	// Database name to be accessed
+	// Database name to be accessed.
 	DatabaseName string
-	// The host used to host the database
+	// The host used to host the database.
 	Host string
-	// The port used to connect to the database
+	// The port used to connect to the database.
 	Port uint16
 }
 
-// Create a valid DSN string to connect database from DsnConfig
+// Create a valid DSN string to connect database from DsnConfig.
 func (config *DsnConfig) String() string {
 	dsn := fmt.Sprintf(
 		"user=%s password=%s dbname=%s host=%s port=%d",
@@ -31,7 +37,7 @@ func (config *DsnConfig) String() string {
 	return dsn
 }
 
-// Connect to database by DsnConfig
+// Connect to database by DsnConfig.
 func ConnectDb(dsnConfig DsnConfig, maxRetries int, retryDelay time.Duration) (*gorm.DB, error) {
 	dsn := dsnConfig.String()
 
@@ -48,11 +54,10 @@ func ConnectDb(dsnConfig DsnConfig, maxRetries int, retryDelay time.Duration) (*
 	return nil, fmt.Errorf("maximum number of retries reached: %w", err)
 }
 
-// AutoMigrate Process table, create, modify if the table is not existed, changed base on model
-func CreateProcessTable(db *gorm.DB) error {
-	err := db.AutoMigrate(&Process{})
-	if err != nil {
-		return fmt.Errorf("failed to create tables: %w", err)
+// Migrate all tables in database automatically.
+func AutoMigrate(db *gorm.DB) error {
+	if err := db.AutoMigrate(migrations...); err != nil {
+		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 
 	return nil

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -38,7 +38,10 @@ func (f *Fetcher) GetInstance(ctx context.Context, instanceKey int64) (Instance,
 // Gets all instances for all processes.
 func (f *Fetcher) GetInstances(ctx context.Context) ([]Instance, error) {
 	var instances []Instance
-	err := f.ContextDB(ctx).Find(&instances).Error
+	err := f.ContextDB(ctx).
+		Order("start_time DESC").
+		Find(&instances).
+		Error
 
 	return instances, err
 }
@@ -48,6 +51,7 @@ func (f *Fetcher) GetInstancesForProcess(ctx context.Context, processDefKey int6
 	var instances []Instance
 	err := f.ContextDB(ctx).
 		Where(&Instance{ProcessDefinitionKey: processDefKey}).
+		Order("start_time DESC").
 		Find(&instances).
 		Error
 
@@ -68,7 +72,10 @@ func (f *Fetcher) GetProcess(ctx context.Context, processDefKey int64) (Process,
 // Gets all processes.
 func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 	var processes []Process
-	err := f.ContextDB(ctx).Find(&processes).Error
+	err := f.ContextDB(ctx).
+		Order("deployment_time DESC").
+		Find(&processes).
+		Error
 
 	return processes, err
 }

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -24,13 +24,7 @@ func (f *Fetcher) ContextDB(ctx context.Context) *gorm.DB {
 	return f.db.WithContext(ctx)
 }
 
-func (f *Fetcher) GetInstances(ctx context.Context) ([]Instance, error) {
-	var instances []Instance
-	err := f.ContextDB(ctx).Find(&instances).Error
-
-	return instances, err
-}
-
+// Gets an instance by its key.
 func (f *Fetcher) GetInstance(ctx context.Context, instanceKey int64) (Instance, error) {
 	var instance Instance
 	err := f.ContextDB(ctx).
@@ -41,6 +35,15 @@ func (f *Fetcher) GetInstance(ctx context.Context, instanceKey int64) (Instance,
 	return instance, err
 }
 
+// Gets all instances for all processes.
+func (f *Fetcher) GetInstances(ctx context.Context) ([]Instance, error) {
+	var instances []Instance
+	err := f.ContextDB(ctx).Find(&instances).Error
+
+	return instances, err
+}
+
+// Gets all instances for a process based on its definition key.
 func (f *Fetcher) GetInstancesForProcess(ctx context.Context, processDefKey int64) ([]Instance, error) {
 	var instances []Instance
 	err := f.ContextDB(ctx).
@@ -49,16 +52,6 @@ func (f *Fetcher) GetInstancesForProcess(ctx context.Context, processDefKey int6
 		Error
 
 	return instances, err
-}
-
-// Gets all processes.
-func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
-	var processes []Process
-	err := f.ContextDB(ctx).
-		Find(&processes).
-		Error
-
-	return processes, err
 }
 
 // Gets a process by its key.
@@ -70,4 +63,12 @@ func (f *Fetcher) GetProcess(ctx context.Context, processDefKey int64) (Process,
 		Error
 
 	return process, err
+}
+
+// Gets all processes.
+func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
+	var processes []Process
+	err := f.ContextDB(ctx).Find(&processes).Error
+
+	return processes, err
 }

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -24,6 +24,16 @@ func (f *Fetcher) ContextDB(ctx context.Context) *gorm.DB {
 	return f.db.WithContext(ctx)
 }
 
+func (f *Fetcher) GetBpmnResource(ctx context.Context, bpmnProcessId string) (BpmnResource, error) {
+	var bpmnResource BpmnResource
+	err := f.ContextDB(ctx).
+		Where(&BpmnResource{BpmnProcessID: bpmnProcessId}).
+		First(&bpmnResource).
+		Error
+
+	return bpmnResource, err
+}
+
 // Gets an instance by its key.
 func (f *Fetcher) GetInstance(ctx context.Context, instanceKey int64) (Instance, error) {
 	var instance Instance

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -24,18 +24,50 @@ func (f *Fetcher) ContextDB(ctx context.Context) *gorm.DB {
 	return f.db.WithContext(ctx)
 }
 
+func (f *Fetcher) GetInstances(ctx context.Context) ([]Instance, error) {
+	var instances []Instance
+	err := f.ContextDB(ctx).Find(&instances).Error
+
+	return instances, err
+}
+
+func (f *Fetcher) GetInstance(ctx context.Context, instanceKey int64) (Instance, error) {
+	var instance Instance
+	err := f.ContextDB(ctx).
+		Where(&Instance{ProcessInstanceKey: instanceKey}).
+		First(&instance).
+		Error
+
+	return instance, err
+}
+
+func (f *Fetcher) GetInstancesForProcess(ctx context.Context, processDefKey int64) ([]Instance, error) {
+	var instances []Instance
+	err := f.ContextDB(ctx).
+		Where(&Instance{ProcessDefinitionKey: processDefKey}).
+		Find(&instances).
+		Error
+
+	return instances, err
+}
+
 // Gets all processes.
 func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 	var processes []Process
-	err := f.ContextDB(ctx).Find(&processes).Error
+	err := f.ContextDB(ctx).
+		Find(&processes).
+		Error
 
 	return processes, err
 }
 
 // Gets a process by its key.
-func (f *Fetcher) GetProcess(ctx context.Context, processKey int64) (Process, error) {
+func (f *Fetcher) GetProcess(ctx context.Context, processDefKey int64) (Process, error) {
 	var process Process
-	err := f.ContextDB(ctx).Where(&Process{ProcessKey: processKey}).First(&process).Error
+	err := f.ContextDB(ctx).
+		Where(&Process{ProcessDefinitionKey: processDefKey}).
+		First(&process).
+		Error
 
 	return process, err
 }

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -24,10 +24,10 @@ func (f *Fetcher) ContextDB(ctx context.Context) *gorm.DB {
 	return f.db.WithContext(ctx)
 }
 
-func (f *Fetcher) GetBpmnResource(ctx context.Context, bpmnProcessId string) (BpmnResource, error) {
+func (f *Fetcher) GetBpmnResource(ctx context.Context, bpmnProcessID string) (BpmnResource, error) {
 	var bpmnResource BpmnResource
 	err := f.ContextDB(ctx).
-		Where(&BpmnResource{BpmnProcessID: bpmnProcessId}).
+		Where(&BpmnResource{BpmnProcessID: bpmnProcessID}).
 		First(&bpmnResource).
 		Error
 

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -8,21 +8,158 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var expectedInstances = []Instance{
+	{
+		ProcessInstanceKey:   10,
+		BpmnProcessID:        "multi-instance-process",
+		ProcessDefinitionKey: 1,
+		Status:               "Active",
+	},
+	{
+		ProcessInstanceKey:   20,
+		BpmnProcessID:        "money-loan",
+		ProcessDefinitionKey: 2,
+		Status:               "Completed",
+	},
+}
+
 var expectedProcesses = []Process{
 	{
 		ProcessDefinitionKey: 1,
 		BpmnProcessID:        "multi-instance-process",
 		BpmnResource:         "hlasd876/fhd=",
+		Instances:            expectedInstances,
 	},
 	{
 		ProcessDefinitionKey: 2,
 		BpmnProcessID:        "money-loan",
 		BpmnResource:         "9I79a8s7gKJH",
+		Instances:            []Instance{},
 	},
 }
 
+func TestInstanceQuery(t *testing.T) {
+	testDb := newMigratedTestDB(t)
+	defer func() {
+		assert.NoError(t, testDb.Rollback())
+	}()
+	db := testDb.DB()
+
+	expectedInstance := &expectedInstances[0]
+	err := db.Create(expectedInstance).Error
+	assert.NoError(t, err)
+
+	fetcher := NewFetcher(db)
+
+	tests := []struct {
+		name        string
+		instanceKey int64
+		expectedErr string
+	}{
+		{
+			name:        "existing instance",
+			instanceKey: expectedInstance.ProcessInstanceKey,
+		},
+		{
+			name:        "non-existent instance",
+			instanceKey: 123,
+			expectedErr: "record not found",
+		},
+	}
+
+	for _, test := range tests {
+		// Capture range variable.
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			instance, err := fetcher.GetInstance(context.Background(), test.instanceKey)
+
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, expectedInstance.ProcessInstanceKey, instance.ProcessInstanceKey)
+			assert.Equal(t, expectedInstance.BpmnProcessID, instance.BpmnProcessID)
+			assert.Equal(t, expectedInstance.ProcessDefinitionKey, instance.ProcessDefinitionKey)
+			assert.Equal(t, expectedInstance.Status, instance.Status)
+		})
+	}
+}
+
+func TestInstancesQuery(t *testing.T) {
+	testDb := newMigratedTestDB(t)
+	defer func() {
+		assert.NoError(t, testDb.Rollback())
+	}()
+	db := testDb.DB()
+
+	err := db.Create(expectedInstances).Error
+	assert.NoError(t, err)
+
+	fetcher := NewFetcher(db)
+
+	instances, err := fetcher.GetInstances(context.Background())
+	assert.NoError(t, err)
+
+	assert.Len(t, instances, 2)
+	for i := range instances {
+		assert.Equal(t, expectedInstances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
+		assert.Equal(t, expectedInstances[i].BpmnProcessID, instances[i].BpmnProcessID)
+		assert.Equal(t, expectedInstances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
+		assert.Equal(t, expectedInstances[i].Status, instances[i].Status)
+	}
+}
+
+func TestInstancesForProcessQuery(t *testing.T) {
+	testDb := newMigratedTestDB(t)
+	defer func() {
+		assert.NoError(t, testDb.Rollback())
+	}()
+	db := testDb.DB()
+
+	err := db.Create(expectedProcesses).Error
+	assert.NoError(t, err)
+
+	fetcher := NewFetcher(db)
+
+	tests := []struct {
+		name          string
+		processDefKey int64
+		instances     []Instance
+	}{
+		{
+			name:          "existing process",
+			processDefKey: 1,
+			instances:     expectedInstances,
+		},
+		{
+			name:          "non-existent process",
+			processDefKey: 2,
+			instances:     []Instance{},
+		},
+	}
+
+	for _, test := range tests {
+		// Capture range variable.
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			instances, err := fetcher.GetInstancesForProcess(context.Background(), test.processDefKey)
+			assert.NoError(t, err)
+
+			assert.Len(t, instances, len(test.instances))
+			for i := range instances {
+				assert.Equal(t, test.instances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
+				assert.Equal(t, test.instances[i].BpmnProcessID, instances[i].BpmnProcessID)
+				assert.Equal(t, test.instances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
+				assert.Equal(t, test.instances[i].Status, instances[i].Status)
+			}
+		})
+	}
+}
+
 func TestProcessesQuery(t *testing.T) {
-	testDb := newProcessesTestDB(t)
+	testDb := newMigratedTestDB(t)
 	defer func() {
 		assert.NoError(t, testDb.Rollback())
 	}()
@@ -45,7 +182,7 @@ func TestProcessesQuery(t *testing.T) {
 }
 
 func TestProcessQuery(t *testing.T) {
-	testDb := newProcessesTestDB(t)
+	testDb := newMigratedTestDB(t)
 	defer func() {
 		assert.NoError(t, testDb.Rollback())
 	}()
@@ -58,18 +195,18 @@ func TestProcessQuery(t *testing.T) {
 	fetcher := NewFetcher(db)
 
 	tests := []struct {
-		name        string
-		processKey  int64
-		expectedErr string
+		name          string
+		processDefKey int64
+		expectedErr   string
 	}{
 		{
-			name:       "existing process",
-			processKey: expectedProcess.ProcessDefinitionKey,
+			name:          "existing process",
+			processDefKey: expectedProcess.ProcessDefinitionKey,
 		},
 		{
-			name:        "non-existent process",
-			processKey:  123,
-			expectedErr: "record not found",
+			name:          "non-existent process",
+			processDefKey: 123,
+			expectedErr:   "record not found",
 		},
 	}
 
@@ -77,7 +214,7 @@ func TestProcessQuery(t *testing.T) {
 		// Capture range variable.
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			process, err := fetcher.GetProcess(context.Background(), test.processKey)
+			process, err := fetcher.GetProcess(context.Background(), test.processDefKey)
 
 			if test.expectedErr != "" {
 				assert.EqualError(t, err, test.expectedErr)
@@ -93,7 +230,7 @@ func TestProcessQuery(t *testing.T) {
 }
 
 func TestCancelQuery(t *testing.T) {
-	testDb := newProcessesTestDB(t)
+	testDb := newMigratedTestDB(t)
 	defer func() {
 		assert.NoError(t, testDb.Rollback())
 	}()
@@ -108,10 +245,10 @@ func TestCancelQuery(t *testing.T) {
 }
 
 // Creates new test database with processes table.
-func newProcessesTestDB(t *testing.T) *testutils.TestDB {
+func newMigratedTestDB(t *testing.T) *testutils.TestDB {
 	testDb := testutils.NewTestDB(t)
 
-	err := testDb.DB().AutoMigrate(&Process{})
+	err := AutoMigrate(testDb.DB())
 	assert.NoError(t, err)
 
 	return testDb

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -11,13 +11,11 @@ import (
 var expectedInstances = []Instance{
 	{
 		ProcessInstanceKey:   10,
-		BpmnProcessID:        "multi-instance-process",
 		ProcessDefinitionKey: 1,
 		Status:               "Active",
 	},
 	{
 		ProcessInstanceKey:   20,
-		BpmnProcessID:        "money-loan",
 		ProcessDefinitionKey: 2,
 		Status:               "Completed",
 	},
@@ -26,14 +24,10 @@ var expectedInstances = []Instance{
 var expectedProcesses = []Process{
 	{
 		ProcessDefinitionKey: 1,
-		BpmnProcessID:        "multi-instance-process",
-		BpmnResource:         "hlasd876/fhd=",
 		Instances:            expectedInstances,
 	},
 	{
 		ProcessDefinitionKey: 2,
-		BpmnProcessID:        "money-loan",
-		BpmnResource:         "9I79a8s7gKJH",
 		Instances:            []Instance{},
 	},
 }
@@ -80,7 +74,6 @@ func TestInstanceQuery(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, expectedInstance.ProcessInstanceKey, instance.ProcessInstanceKey)
-			assert.Equal(t, expectedInstance.BpmnProcessID, instance.BpmnProcessID)
 			assert.Equal(t, expectedInstance.ProcessDefinitionKey, instance.ProcessDefinitionKey)
 			assert.Equal(t, expectedInstance.Status, instance.Status)
 		})
@@ -105,7 +98,6 @@ func TestInstancesQuery(t *testing.T) {
 	assert.Len(t, instances, 2)
 	for i := range instances {
 		assert.Equal(t, expectedInstances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
-		assert.Equal(t, expectedInstances[i].BpmnProcessID, instances[i].BpmnProcessID)
 		assert.Equal(t, expectedInstances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
 		assert.Equal(t, expectedInstances[i].Status, instances[i].Status)
 	}
@@ -150,7 +142,6 @@ func TestInstancesForProcessQuery(t *testing.T) {
 			assert.Len(t, instances, len(test.instances))
 			for i := range instances {
 				assert.Equal(t, test.instances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
-				assert.Equal(t, test.instances[i].BpmnProcessID, instances[i].BpmnProcessID)
 				assert.Equal(t, test.instances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
 				assert.Equal(t, test.instances[i].Status, instances[i].Status)
 			}
@@ -176,8 +167,6 @@ func TestProcessesQuery(t *testing.T) {
 	assert.Len(t, processes, 2)
 	for i := range processes {
 		assert.Equal(t, expectedProcesses[i].ProcessDefinitionKey, processes[i].ProcessDefinitionKey)
-		assert.Equal(t, expectedProcesses[i].BpmnProcessID, processes[i].BpmnProcessID)
-		assert.Equal(t, expectedProcesses[i].BpmnResource, processes[i].BpmnResource)
 	}
 }
 
@@ -223,8 +212,6 @@ func TestProcessQuery(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, expectedProcess.ProcessDefinitionKey, process.ProcessDefinitionKey)
-			assert.Equal(t, expectedProcess.BpmnProcessID, process.BpmnProcessID)
-			assert.Equal(t, expectedProcess.BpmnResource, process.BpmnResource)
 		})
 	}
 }

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -10,14 +10,14 @@ import (
 
 var expectedProcesses = []Process{
 	{
-		ProcessKey:    1,
-		BpmnProcessID: "multi-instance-process",
-		BpmnResource:  "hlasd876/fhd=",
+		ProcessDefinitionKey: 1,
+		BpmnProcessID:        "multi-instance-process",
+		BpmnResource:         "hlasd876/fhd=",
 	},
 	{
-		ProcessKey:    2,
-		BpmnProcessID: "money-loan",
-		BpmnResource:  "9I79a8s7gKJH",
+		ProcessDefinitionKey: 2,
+		BpmnProcessID:        "money-loan",
+		BpmnResource:         "9I79a8s7gKJH",
 	},
 }
 
@@ -38,7 +38,7 @@ func TestProcessesQuery(t *testing.T) {
 
 	assert.Len(t, processes, 2)
 	for i := range processes {
-		assert.Equal(t, expectedProcesses[i].ProcessKey, processes[i].ProcessKey)
+		assert.Equal(t, expectedProcesses[i].ProcessDefinitionKey, processes[i].ProcessDefinitionKey)
 		assert.Equal(t, expectedProcesses[i].BpmnProcessID, processes[i].BpmnProcessID)
 		assert.Equal(t, expectedProcesses[i].BpmnResource, processes[i].BpmnResource)
 	}
@@ -64,7 +64,7 @@ func TestProcessQuery(t *testing.T) {
 	}{
 		{
 			name:       "existing process",
-			processKey: expectedProcess.ProcessKey,
+			processKey: expectedProcess.ProcessDefinitionKey,
 		},
 		{
 			name:        "non-existent process",
@@ -85,7 +85,7 @@ func TestProcessQuery(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			assert.Equal(t, expectedProcess.ProcessKey, process.ProcessKey)
+			assert.Equal(t, expectedProcess.ProcessDefinitionKey, process.ProcessDefinitionKey)
 			assert.Equal(t, expectedProcess.BpmnProcessID, process.BpmnProcessID)
 			assert.Equal(t, expectedProcess.BpmnResource, process.BpmnResource)
 		})

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -12,22 +12,24 @@ var expectedInstances = []Instance{
 	{
 		ProcessInstanceKey:   10,
 		ProcessDefinitionKey: 1,
-		Status:               "Active",
+		Status:               "ACTIVE",
 	},
 	{
 		ProcessInstanceKey:   20,
 		ProcessDefinitionKey: 2,
-		Status:               "Completed",
+		Status:               "COMPLETED",
 	},
 }
 
 var expectedProcesses = []Process{
 	{
 		ProcessDefinitionKey: 1,
+		BpmnProcessID:        "process1",
 		Instances:            expectedInstances,
 	},
 	{
 		ProcessDefinitionKey: 2,
+		BpmnProcessID:        "process2",
 		Instances:            []Instance{},
 	},
 }
@@ -39,8 +41,8 @@ func TestInstanceQuery(t *testing.T) {
 	}()
 	db := testDb.DB()
 
-	expectedInstance := &expectedInstances[0]
-	err := db.Create(expectedInstance).Error
+	expectedInstance := expectedInstances[0]
+	err := db.Create(&expectedInstance).Error
 	assert.NoError(t, err)
 
 	fetcher := NewFetcher(db)
@@ -73,9 +75,7 @@ func TestInstanceQuery(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			assert.Equal(t, expectedInstance.ProcessInstanceKey, instance.ProcessInstanceKey)
-			assert.Equal(t, expectedInstance.ProcessDefinitionKey, instance.ProcessDefinitionKey)
-			assert.Equal(t, expectedInstance.Status, instance.Status)
+			assert.Equal(t, expectedInstance, instance)
 		})
 	}
 }
@@ -97,9 +97,7 @@ func TestInstancesQuery(t *testing.T) {
 
 	assert.Len(t, instances, 2)
 	for i := range instances {
-		assert.Equal(t, expectedInstances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
-		assert.Equal(t, expectedInstances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
-		assert.Equal(t, expectedInstances[i].Status, instances[i].Status)
+		assert.Equal(t, expectedInstances[i], instances[i])
 	}
 }
 
@@ -141,9 +139,7 @@ func TestInstancesForProcessQuery(t *testing.T) {
 
 			assert.Len(t, instances, len(test.instances))
 			for i := range instances {
-				assert.Equal(t, test.instances[i].ProcessInstanceKey, instances[i].ProcessInstanceKey)
-				assert.Equal(t, test.instances[i].ProcessDefinitionKey, instances[i].ProcessDefinitionKey)
-				assert.Equal(t, test.instances[i].Status, instances[i].Status)
+				assert.Equal(t, test.instances[i], instances[i])
 			}
 		})
 	}

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -1,11 +1,23 @@
 package storage
 
-import "gorm.io/gorm"
+import (
+	"time"
+)
 
-// Process model struct for database table.
+// Instance model struct for the 'instances' database table.
+type Instance struct {
+	ProcessInstanceKey   int64     `gorm:"primarykey"`
+	BpmnProcessID        string    `gorm:"not null"`
+	ProcessDefinitionKey int64     `gorm:"not null"`
+	Status               string    `gorm:"not null"`
+	StartTime            time.Time `gorm:"not null"`
+}
+
+// Process model struct for the 'processes' database table.
 type Process struct {
-	gorm.Model
-	BpmnProcessID string `gorm:"unique;not null"`
-	ProcessKey    int64  `gorm:"unique;not null"`
-	BpmnResource  string `gorm:"not null"`
+	ProcessDefinitionKey int64      `gorm:"primarykey"`
+	BpmnProcessID        string     `gorm:"not null"`
+	Version              int64      `gorm:"not null"`
+	BpmnResource         string     `gorm:"not null"`
+	Instances            []Instance `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
 }

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -2,23 +2,34 @@ package storage
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // Instance model struct for the 'instances' database table.
 type Instance struct {
 	ProcessInstanceKey   int64     `gorm:"primarykey"`
-	BpmnProcessID        string    `gorm:"not null"`
 	ProcessDefinitionKey int64     `gorm:"not null"`
 	Status               string    `gorm:"not null"`
 	StartTime            time.Time `gorm:"not null"`
+	BpmnProcessID        string    `gorm:"not null"`
 }
 
 // Process model struct for the 'processes' database table.
 type Process struct {
 	ProcessDefinitionKey int64      `gorm:"primarykey"`
-	BpmnProcessID        string     `gorm:"not null"`
 	Version              int64      `gorm:"not null"`
-	BpmnResource         string     `gorm:"not null"`
 	DeploymentTime       time.Time  `gorm:"not null"`
+	BpmnProcessID        string     `gorm:"not null"`
 	Instances            []Instance `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
+}
+
+// BpmnResource model struct for the 'bpmn_resources' database table.
+//
+// This table is used to store the BPMN XML files which are relatively large
+// in size. The XML files are stored in the database as a base64 encoded string.
+type BpmnResource struct {
+	gorm.Model
+	BpmnProcessID string `gorm:"unique"`
+	BpmnFile      string `gorm:"not null"`
 }

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -8,6 +8,7 @@ import (
 type Instance struct {
 	ProcessInstanceKey   int64     `gorm:"primarykey"`
 	ProcessDefinitionKey int64     `gorm:"not null"`
+	Version              int64     `gorm:"not null"`
 	Status               string    `gorm:"not null"`
 	StartTime            time.Time `gorm:"not null"`
 }

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -19,5 +19,6 @@ type Process struct {
 	BpmnProcessID        string     `gorm:"not null"`
 	Version              int64      `gorm:"not null"`
 	BpmnResource         string     `gorm:"not null"`
+	DeploymentTime       time.Time  `gorm:"not null"`
 	Instances            []Instance `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
 }

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -2,8 +2,6 @@ package storage
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 // Instance model struct for the 'instances' database table.
@@ -12,16 +10,16 @@ type Instance struct {
 	ProcessDefinitionKey int64     `gorm:"not null"`
 	Status               string    `gorm:"not null"`
 	StartTime            time.Time `gorm:"not null"`
-	BpmnProcessID        string    `gorm:"not null"`
 }
 
 // Process model struct for the 'processes' database table.
 type Process struct {
-	ProcessDefinitionKey int64      `gorm:"primarykey"`
-	Version              int64      `gorm:"not null"`
-	DeploymentTime       time.Time  `gorm:"not null"`
-	BpmnProcessID        string     `gorm:"not null"`
-	Instances            []Instance `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
+	ProcessDefinitionKey int64        `gorm:"primarykey"`
+	BpmnProcessID        string       `gorm:"unique;not null"`
+	Version              int64        `gorm:"not null"`
+	DeploymentTime       time.Time    `gorm:"not null"`
+	BpmnResource         BpmnResource `gorm:"foreignKey:BpmnProcessID;references:BpmnProcessID"`
+	Instances            []Instance   `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
 }
 
 // BpmnResource model struct for the 'bpmn_resources' database table.
@@ -29,7 +27,7 @@ type Process struct {
 // This table is used to store the BPMN XML files which are relatively large
 // in size. The XML files are stored in the database as a base64 encoded string.
 type BpmnResource struct {
-	gorm.Model
-	BpmnProcessID string `gorm:"unique"`
-	BpmnFile      string `gorm:"not null"`
+	BpmnProcessID string `gorm:"primarykey"`
+	// A base64 encoded string of the BPMN XML file.
+	BpmnFile string `gorm:"not null"`
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
+    depends_on:
+      - postgres
 
   postgres:
     image: postgres:16.0

--- a/frontend/src/pages/InstancesPage.tsx
+++ b/frontend/src/pages/InstancesPage.tsx
@@ -7,7 +7,9 @@ export default function InstancesPage() {
     query Instances {
       instances {
         instanceKey
-        bpmnProcessId
+        process {
+          bpmnProcessId
+        }
         status
         startTime
       }
@@ -25,12 +27,12 @@ export default function InstancesPage() {
           ? data.instances.map(
               ({
                 instanceKey,
-                bpmnProcessId,
+                process: { bpmnProcessId },
                 status,
                 startTime,
               }: {
-                instanceKey: number;
-                bpmnProcessId: string;
+                instanceKey: string;
+                process: { bpmnProcessId: string };
                 status: string;
                 startTime: string;
               }) => [instanceKey, bpmnProcessId, status, startTime],


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#119

### Description
<!-- Please add what is included in this pull request. -->
- Added `instances` table
- Moved BPMN files to separate `bpmn_resources` table
- Added more fields to `processes` table
- Implemented GraphQL API to allow querying instances through Fetch API.

BPMN files were separated to another table so they can be queried independently and only when they're needed, because of their large (~500 kB) size. Frontend wasn't adjusted to accommodate this leaner strategy (query bpmn file once instead of polling) due to time constraints.

All new internal APIs (excludes GraphQL API) have tests.

NOTE: all records are ordered from newest to oldest in the backend, but table component in the frontend seems to have a bug which causes to reverse them.

### Testing
<!-- How can code reviewers test this PR? -->
First ensure that database is not yet initialized from previous runs:

```bash
$ docker compose down --volumes
```

1. Start the test bench
2. Start ZeeVision
3. Open zeevision_db in pgAdmin

Insert the query below to pgAdmin to create a process with associated bpmn resource, and add a instance of that process. Replace `bpmn_file` with base64 encoded BPMN file. You can create the encoded file from one of the files in `zeebe-test-bench/zeebe-workflow-manager/src/main/resources/bpmn` with command:

```bash
$ base64 -w 0 <file>
```

The queries to run:

```sql
INSERT INTO processes(process_definition_key, bpmn_process_id, version, deployment_time)
VALUES(123, 'hello-world', 1, NOW());

INSERT INTO bpmn_resources(bpmn_process_id, bpmn_file)
VALUES('hello-world', '<the bpmn file>');

INSERT INTO instances(process_instance_key, process_definition_key, version, status, start_time)
VALUES(1, 123, 1, 'ACTIVE', NOW());
```

Check that processes page has one process. It also should have visible BPMN figure, and instance in its instances list.
Check that instances page has the same instance that the process had.