### PR TITLE
fix(frontend): default to use content order in table component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,6 @@
         "zustand": "^4.4.6"
       },
       "devDependencies": {
-        "@esbuild/linux-x64": "^0.19.7",
         "@storybook/addon-essentials": "^7.5.3",
         "@storybook/addon-interactions": "^7.5.3",
         "@storybook/addon-links": "^7.5.3",
@@ -2747,21 +2746,6 @@
       ],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.7.tgz",
-      "integrity": "sha512-ZYZopyLhm4mcoZXjFt25itRlocKlcazDVkB4AhioiL9hOWhDldU9n38g62fhOI4Pth6vp+Mrd5rFKxD0/S+7aQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
       "os": [
         "linux"
       ],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "zustand": "^4.4.6"
       },
       "devDependencies": {
+        "@esbuild/linux-x64": "^0.19.7",
         "@storybook/addon-essentials": "^7.5.3",
         "@storybook/addon-interactions": "^7.5.3",
         "@storybook/addon-links": "^7.5.3",
@@ -65,6 +66,19 @@
         "ts-node": "^10.9.1",
         "typescript": "^5.3.2",
         "vite": "^4.5.0"
+      },
+      "optionalDependencies": {
+        "@swc/core": "^1.3.99",
+        "@swc/core-darwin-arm64": "^1.3.99",
+        "@swc/core-darwin-x64": "^1.3.99",
+        "@swc/core-linux-arm-gnueabihf": "^1.3.96",
+        "@swc/core-linux-arm64-gnu": "^1.3.99",
+        "@swc/core-linux-arm64-musl": "^1.3.99",
+        "@swc/core-linux-x64-gnu": "^1.3.99",
+        "@swc/core-linux-x64-musl": "^1.3.99",
+        "@swc/core-win32-arm64-msvc": "^1.3.99",
+        "@swc/core-win32-ia32-msvc": "^1.3.99",
+        "@swc/core-win32-x64-msvc": "^1.3.99"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2500,6 +2514,54 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
@@ -2511,6 +2573,293 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.7.tgz",
+      "integrity": "sha512-ZYZopyLhm4mcoZXjFt25itRlocKlcazDVkB4AhioiL9hOWhDldU9n38g62fhOI4Pth6vp+Mrd5rFKxD0/S+7aQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -5794,10 +6143,10 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.96",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.96.tgz",
-      "integrity": "sha512-zwE3TLgoZwJfQygdv2SdCK9mRLYluwDOM53I+dT6Z5ZvrgVENmY3txvWDvduzkV+/8IuvrRbVezMpxcojadRdQ==",
-      "dev": true,
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.99.tgz",
+      "integrity": "sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==",
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.1",
@@ -5811,16 +6160,15 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.96",
-        "@swc/core-darwin-x64": "1.3.96",
-        "@swc/core-linux-arm-gnueabihf": "1.3.96",
-        "@swc/core-linux-arm64-gnu": "1.3.96",
-        "@swc/core-linux-arm64-musl": "1.3.96",
-        "@swc/core-linux-x64-gnu": "1.3.96",
-        "@swc/core-linux-x64-musl": "1.3.96",
-        "@swc/core-win32-arm64-msvc": "1.3.96",
-        "@swc/core-win32-ia32-msvc": "1.3.96",
-        "@swc/core-win32-x64-msvc": "1.3.96"
+        "@swc/core-darwin-arm64": "1.3.99",
+        "@swc/core-darwin-x64": "1.3.99",
+        "@swc/core-linux-arm64-gnu": "1.3.99",
+        "@swc/core-linux-arm64-musl": "1.3.99",
+        "@swc/core-linux-x64-gnu": "1.3.99",
+        "@swc/core-linux-x64-musl": "1.3.99",
+        "@swc/core-win32-arm64-msvc": "1.3.99",
+        "@swc/core-win32-ia32-msvc": "1.3.99",
+        "@swc/core-win32-x64-msvc": "1.3.99"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -5832,16 +6180,150 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.96",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.96.tgz",
-      "integrity": "sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==",
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.99.tgz",
+      "integrity": "sha512-Qj7Jct68q3ZKeuJrjPx7k8SxzWN6PqLh+VFxzA+KwLDpQDPzOlKRZwkIMzuFjLhITO4RHgSnXoDk/Syz0ZeN+Q==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.99.tgz",
+      "integrity": "sha512-wR7m9QVJjgiBu1PSOHy7s66uJPa45Kf9bZExXUL+JAa9OQxt5y+XVzr+n+F045VXQOwdGWplgPnWjgbUUHEVyw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.96.tgz",
+      "integrity": "sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.99.tgz",
+      "integrity": "sha512-gcGv1l5t0DScEONmw5OhdVmEI/o49HCe9Ik38zzH0NtDkc+PDYaCcXU5rvfZP2qJFaAAr8cua8iJcOunOSLmnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.99.tgz",
+      "integrity": "sha512-XL1/eUsTO8BiKsWq9i3iWh7H99iPO61+9HYiWVKhSavknfj4Plbn+XyajDpxsauln5o8t+BRGitymtnAWJM4UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.99.tgz",
+      "integrity": "sha512-fGrXYE6DbTfGNIGQmBefYxSk3rp/1lgbD0nVg4rl4mfFRQPi7CgGhrrqSuqZ/ezXInUIgoCyvYGWFSwjLXt/Qg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.99.tgz",
+      "integrity": "sha512-kvgZp/mqf3IJ806gUOL6gN6VU15+DfzM1Zv4Udn8GqgXiUAvbQehrtruid4Snn5pZTLj4PEpSCBbxgxK1jbssA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.99.tgz",
+      "integrity": "sha512-yt8RtZ4W/QgFF+JUemOUQAkVW58cCST7mbfKFZ1v16w3pl3NcWd9OrtppFIXpbjU1rrUX2zp2R7HZZzZ2Zk/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.99.tgz",
+      "integrity": "sha512-62p5fWnOJR/rlbmbUIpQEVRconICy5KDScWVuJg1v3GPLBrmacjphyHiJC1mp6dYvvoEWCk/77c/jcQwlXrDXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.99",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.99.tgz",
+      "integrity": "sha512-PdppWhkoS45VGdMBxvClVgF1hVjqamtvYd82Gab1i4IV45OSym2KinoDCKE1b6j3LwBLOn2J9fvChGSgGfDCHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -5851,13 +6333,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
       "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@swc/types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
@@ -9027,6 +9509,22 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,6 @@
     "zustand": "^4.4.6"
   },
   "devDependencies": {
-    "@esbuild/linux-x64": "^0.19.7",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-interactions": "^7.5.3",
     "@storybook/addon-links": "^7.5.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "zustand": "^4.4.6"
   },
   "devDependencies": {
+    "@esbuild/linux-x64": "^0.19.7",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-interactions": "^7.5.3",
     "@storybook/addon-links": "^7.5.3",
@@ -73,5 +74,18 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.2",
     "vite": "^4.5.0"
+  },
+  "optionalDependencies": {
+    "@swc/core": "^1.3.99",
+    "@swc/core-darwin-arm64": "^1.3.99",
+    "@swc/core-darwin-x64": "^1.3.99",
+    "@swc/core-linux-arm-gnueabihf": "^1.3.96",
+    "@swc/core-linux-arm64-gnu": "^1.3.99",
+    "@swc/core-linux-arm64-musl": "^1.3.99",
+    "@swc/core-linux-x64-gnu": "^1.3.99",
+    "@swc/core-linux-x64-musl": "^1.3.99",
+    "@swc/core-win32-arm64-msvc": "^1.3.99",
+    "@swc/core-win32-ia32-msvc": "^1.3.99",
+    "@swc/core-win32-x64-msvc": "^1.3.99"
   }
 }

--- a/frontend/src/components/Table/HorizontalTable.tsx
+++ b/frontend/src/components/Table/HorizontalTable.tsx
@@ -14,7 +14,7 @@ export function HorizontalTable({ header, content }: HorizontalTableProps) {
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
   const [sortBy, setSortBy] = React.useState("");
-  const [sortOrder, setSortOrder] = React.useState("asc");
+  const [sortOrder, setSortOrder] = React.useState("desc");
   const [sortedContent, setSortedContent] =
     React.useState<(string | number)[][]>(content);
 

--- a/frontend/src/components/Table/__snapshots__/table.test.tsx.snap
+++ b/frontend/src/components/Table/__snapshots__/table.test.tsx.snap
@@ -87,144 +87,6 @@ exports[`HorizontalTable Component renders correctly 1`] = `
           class="p-3"
         >
           <pre>
-            sixth-multi-instance-process
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            amp
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            integer
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            2251799813984642
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            1696667164
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            Show History
-          </pre>
-        </td>
-      </tr>
-      <tr
-        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
-      >
-        <td
-          class="p-3"
-        >
-          <pre>
-            new-multi-instance-process
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            kmean
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            newValue
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            2251799813984100
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            1696667542
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            Show History
-          </pre>
-        </td>
-      </tr>
-      <tr
-        class="border-b border-black/10 hover:bg-second-accent/10"
-      >
-        <td
-          class="p-3"
-        >
-          <pre>
-            another-multi-instance-process
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            anotherVariable
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            string
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            2251799813984432
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            1696667333
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            Show History
-          </pre>
-        </td>
-      </tr>
-      <tr
-        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
-      >
-        <td
-          class="p-3"
-        >
-          <pre>
             multi-instance-process
           </pre>
         </td>
@@ -232,14 +94,27 @@ exports[`HorizontalTable Component renders correctly 1`] = `
           class="p-3"
         >
           <pre>
-            total
+            items
           </pre>
         </td>
         <td
           class="p-3"
         >
           <pre>
-            200
+            [
+  {
+    "id": 1,
+    "value": 10,
+    "inCart": 10,
+    "inStock": 20
+  },
+  {
+    "id": 2,
+    "value": 20,
+    "inCart": 2,
+    "inStock": 10
+  }
+]
           </pre>
         </td>
         <td
@@ -265,7 +140,7 @@ exports[`HorizontalTable Component renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="border-b border-black/10 hover:bg-second-accent/10"
+        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
       >
         <td
           class="p-3"
@@ -311,7 +186,191 @@ exports[`HorizontalTable Component renders correctly 1`] = `
         </td>
       </tr>
       <tr
+        class="border-b border-black/10 hover:bg-second-accent/10"
+      >
+        <td
+          class="p-3"
+        >
+          <pre>
+            multi-instance-process
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            total
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            200
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            2251799813984108
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            1696667765
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            Show History
+          </pre>
+        </td>
+      </tr>
+      <tr
         class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
+      >
+        <td
+          class="p-3"
+        >
+          <pre>
+            another-multi-instance-process
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            anotherVariable
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            string
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            2251799813984432
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            1696667333
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            Show History
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="border-b border-black/10 hover:bg-second-accent/10"
+      >
+        <td
+          class="p-3"
+        >
+          <pre>
+            new-multi-instance-process
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            kmean
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            newValue
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            2251799813984100
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            1696667542
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            Show History
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
+      >
+        <td
+          class="p-3"
+        >
+          <pre>
+            sixth-multi-instance-process
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            amp
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            integer
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            2251799813984642
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            1696667164
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            Show History
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="border-b border-black/10 hover:bg-second-accent/10"
       >
         <td
           class="p-3"
@@ -370,87 +429,41 @@ exports[`HorizontalTable Component renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="border-b border-black/10 hover:bg-second-accent/10"
-      >
-        <td
-          class="p-3"
-        >
-          <pre>
-            sixth-multi-instance-process
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            amp
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            integer
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            2251799813984642
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            1696667164
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            Show History
-          </pre>
-        </td>
-      </tr>
-      <tr
         class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
       >
         <td
           class="p-3"
         >
           <pre>
-            new-multi-instance-process
+            multi-instance-process
           </pre>
         </td>
         <td
           class="p-3"
         >
           <pre>
-            kmean
+            isValid
           </pre>
         </td>
         <td
           class="p-3"
         >
           <pre>
-            newValue
+            true
           </pre>
         </td>
         <td
           class="p-3"
         >
           <pre>
-            2251799813984100
+            2251799813984108
           </pre>
         </td>
         <td
           class="p-3"
         >
           <pre>
-            1696667542
+            1696667765
           </pre>
         </td>
         <td
@@ -463,52 +476,6 @@ exports[`HorizontalTable Component renders correctly 1`] = `
       </tr>
       <tr
         class="border-b border-black/10 hover:bg-second-accent/10"
-      >
-        <td
-          class="p-3"
-        >
-          <pre>
-            another-multi-instance-process
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            anotherVariable
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            string
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            2251799813984432
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            1696667333
-          </pre>
-        </td>
-        <td
-          class="p-3"
-        >
-          <pre>
-            Show History
-          </pre>
-        </td>
-      </tr>
-      <tr
-        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
       >
         <td
           class="p-3"
@@ -543,6 +510,52 @@ exports[`HorizontalTable Component renders correctly 1`] = `
         >
           <pre>
             1696667765
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            Show History
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="border-b border-black/10 bg-second-accent hover:bg-second-accent/20"
+      >
+        <td
+          class="p-3"
+        >
+          <pre>
+            another-multi-instance-process
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            anotherVariable
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            string
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            2251799813984432
+          </pre>
+        </td>
+        <td
+          class="p-3"
+        >
+          <pre>
+            1696667333
           </pre>
         </td>
         <td

--- a/frontend/src/components/Table/table.test.tsx
+++ b/frontend/src/components/Table/table.test.tsx
@@ -55,7 +55,7 @@ describe("HorizontalTable Component", () => {
     );
     expect(getByText("Variable value")).toBeInTheDocument();
     expect(getAllByText("multi-instance-process")[0]).toBeInTheDocument();
-    expect(getAllByText("multi-instance-process").length).toEqual(4);
+    expect(getAllByText("multi-instance-process").length).toEqual(6);
   });
 
   it("renders header and pagination when the content is empty", () => {


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#125

### Description
<!-- Please add what is included in this pull request. -->
Table changed the order of the content by default. Now content is shown as is without sorting options applied.

Build on x64 Linux was also failing locally (not in a container), so I added the required dependencies to fix that.

### Testing
<!-- How can code reviewers test this PR? -->
- Start test bench
- Start zeevision
- Initialize database

```sql
INSERT INTO processes(process_definition_key, bpmn_process_id, version, deployment_time)
VALUES(123, 'hello-world', 1, NOW());

INSERT INTO bpmn_resources(bpmn_process_id, bpmn_file)
VALUES('hello-world', '<the bpmn file>');

INSERT INTO instances(process_instance_key, process_definition_key, version, status, start_time)
VALUES(1, 123, 1, 'ACTIVE', NOW());
```

Wait a moment and add another instance (for the `start_time` to be different):

```sql
INSERT INTO instances(process_instance_key, process_definition_key, version, status, start_time)
VALUES(2, 123, 1, 'ACTIVE', NOW());
```

Validate that GraphQL and instance tables both have the instances in the same order, from newest to oldest.