### PR TITLE
feat(backend): add variables and endTime fields to instance

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -50,11 +50,13 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 	Instance struct {
 		BpmnLiveStatus func(childComplexity int) int
+		EndTime        func(childComplexity int) int
 		InstanceKey    func(childComplexity int) int
 		Process        func(childComplexity int) int
 		ProcessKey     func(childComplexity int) int
 		StartTime      func(childComplexity int) int
 		Status         func(childComplexity int) int
+		Variables      func(childComplexity int) int
 		Version        func(childComplexity int) int
 	}
 
@@ -93,9 +95,17 @@ type ComplexityRoot struct {
 		StartTime          func(childComplexity int) int
 		Status             func(childComplexity int) int
 	}
+
+	Variable struct {
+		ElementID func(childComplexity int) int
+		Name      func(childComplexity int) int
+		Time      func(childComplexity int) int
+		Value     func(childComplexity int) int
+	}
 }
 
 type InstanceResolver interface {
+	Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error)
 	Process(ctx context.Context, obj *model.Instance) (*model.Process, error)
 }
 type ProcessResolver interface {
@@ -139,6 +149,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Instance.BpmnLiveStatus(childComplexity), true
 
+	case "Instance.endTime":
+		if e.complexity.Instance.EndTime == nil {
+			break
+		}
+
+		return e.complexity.Instance.EndTime(childComplexity), true
+
 	case "Instance.instanceKey":
 		if e.complexity.Instance.InstanceKey == nil {
 			break
@@ -173,6 +190,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Instance.Status(childComplexity), true
+
+	case "Instance.variables":
+		if e.complexity.Instance.Variables == nil {
+			break
+		}
+
+		return e.complexity.Instance.Variables(childComplexity), true
 
 	case "Instance.version":
 		if e.complexity.Instance.Version == nil {
@@ -358,6 +382,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Timer.Status(childComplexity), true
+
+	case "Variable.elementId":
+		if e.complexity.Variable.ElementID == nil {
+			break
+		}
+
+		return e.complexity.Variable.ElementID(childComplexity), true
+
+	case "Variable.name":
+		if e.complexity.Variable.Name == nil {
+			break
+		}
+
+		return e.complexity.Variable.Name(childComplexity), true
+
+	case "Variable.time":
+		if e.complexity.Variable.Time == nil {
+			break
+		}
+
+		return e.complexity.Variable.Time(childComplexity), true
+
+	case "Variable.value":
+		if e.complexity.Variable.Value == nil {
+			break
+		}
+
+		return e.complexity.Variable.Value(childComplexity), true
 
 	}
 	return 0, false
@@ -638,6 +690,50 @@ func (ec *executionContext) fieldContext_Instance_startTime(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Instance_endTime(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_endTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EndTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNDateTime2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_endTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DateTime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Instance_instanceKey(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Instance_instanceKey(ctx, field)
 	if err != nil {
@@ -809,6 +905,60 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Instance_variables(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_variables(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Instance().Variables(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Variable)
+	fc.Result = res
+	return ec.marshalNVariable2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐVariableᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_variables(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "elementId":
+				return ec.fieldContext_Variable_elementId(ctx, field)
+			case "name":
+				return ec.fieldContext_Variable_name(ctx, field)
+			case "value":
+				return ec.fieldContext_Variable_value(ctx, field)
+			case "time":
+				return ec.fieldContext_Variable_time(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Variable", field.Name)
 		},
 	}
 	return fc, nil
@@ -1365,6 +1515,8 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "endTime":
+				return ec.fieldContext_Instance_endTime(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
 			case "processKey":
@@ -1373,6 +1525,8 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "variables":
+				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
 				return ec.fieldContext_Instance_process(ctx, field)
 			}
@@ -1767,6 +1921,8 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "endTime":
+				return ec.fieldContext_Instance_endTime(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
 			case "processKey":
@@ -1775,6 +1931,8 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "variables":
+				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
 				return ec.fieldContext_Instance_process(ctx, field)
 			}
@@ -1824,6 +1982,8 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "endTime":
+				return ec.fieldContext_Instance_endTime(ctx, field)
 			case "instanceKey":
 				return ec.fieldContext_Instance_instanceKey(ctx, field)
 			case "processKey":
@@ -1832,6 +1992,8 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "variables":
+				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
 				return ec.fieldContext_Instance_process(ctx, field)
 			}
@@ -2196,6 +2358,182 @@ func (ec *executionContext) fieldContext_Timer_status(ctx context.Context, field
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Variable_elementId(ctx context.Context, field graphql.CollectedField, obj *model.Variable) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Variable_elementId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ElementID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Variable_elementId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Variable",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Variable_name(ctx context.Context, field graphql.CollectedField, obj *model.Variable) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Variable_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Variable_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Variable",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Variable_value(ctx context.Context, field graphql.CollectedField, obj *model.Variable) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Variable_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Variable_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Variable",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Variable_time(ctx context.Context, field graphql.CollectedField, obj *model.Variable) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Variable_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Time, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNDateTime2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Variable_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Variable",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DateTime does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4003,6 +4341,11 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "endTime":
+			out.Values[i] = ec._Instance_endTime(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "instanceKey":
 			out.Values[i] = ec._Instance_instanceKey(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -4023,6 +4366,42 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "variables":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Instance_variables(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "process":
 			field := field
 
@@ -4514,6 +4893,60 @@ func (ec *executionContext) _Timer(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "status":
 			out.Values[i] = ec._Timer_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var variableImplementors = []string{"Variable"}
+
+func (ec *executionContext) _Variable(ctx context.Context, sel ast.SelectionSet, obj *model.Variable) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, variableImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Variable")
+		case "elementId":
+			out.Values[i] = ec._Variable_elementId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._Variable_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._Variable_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "time":
+			out.Values[i] = ec._Variable_time(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -5154,6 +5587,60 @@ func (ec *executionContext) marshalNTimer2ᚖgithubᚗcomᚋducanhpham0312ᚋzee
 		return graphql.Null
 	}
 	return ec._Timer(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNVariable2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐVariableᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Variable) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNVariable2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐVariable(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNVariable2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐVariable(ctx context.Context, sel ast.SelectionSet, v *model.Variable) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Variable(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -35,7 +35,8 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
-		StartTime:      instance.StartTime.UTC().Format(time.RFC3339),
+		StartTime:      formatTime(instance.StartTime),
+		EndTime:        formatTime(instance.EndTime),
 		InstanceKey:    instance.ProcessInstanceKey,
 		ProcessKey:     instance.ProcessDefinitionKey,
 		Version:        instance.Version,
@@ -51,10 +52,23 @@ func FromStorageProcess(process storage.Process) *Process {
 		CompletedInstances: 0,  // TODO
 		BpmnLiveStatus:     "", // TODO
 		BpmnProcessID:      process.BpmnProcessID,
-		DeploymentTime:     process.DeploymentTime.UTC().Format(time.RFC3339),
+		DeploymentTime:     formatTime(process.DeploymentTime),
 		ProcessKey:         process.ProcessDefinitionKey,
 		Version:            process.Version,
 		// Instances, MessageSubscriptions, Timers, BpmnResource have their
 		// own resolvers and are not populated here.
 	}
+}
+
+func FromStorageVariable(variable storage.Variable) *Variable {
+	return &Variable{
+		ElementID: variable.ElementID,
+		Name:      variable.Name,
+		Value:     variable.Value,
+		Time:      formatTime(variable.Time),
+	}
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
 }

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -46,10 +46,12 @@ func TestFromStorageInstance(t *testing.T) {
 				Version:              1,
 				Status:               "ACTIVE",
 				StartTime:            now,
+				EndTime:              now,
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
+				EndTime:        now.UTC().Format(time.RFC3339),
 				InstanceKey:    10,
 				ProcessKey:     1,
 				Version:        1,
@@ -64,10 +66,12 @@ func TestFromStorageInstance(t *testing.T) {
 				Version:              2,
 				Status:               "COMPLETED",
 				StartTime:            now,
+				EndTime:              now,
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
 				StartTime:      now.UTC().Format(time.RFC3339),
+				EndTime:        now.UTC().Format(time.RFC3339),
 				InstanceKey:    20,
 				ProcessKey:     2,
 				Version:        2,

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -9,13 +9,15 @@ import (
 )
 
 type Instance struct {
-	BpmnLiveStatus string   `json:"bpmnLiveStatus"`
-	StartTime      string   `json:"startTime"`
-	InstanceKey    int64    `json:"instanceKey"`
-	ProcessKey     int64    `json:"processKey"`
-	Version        int64    `json:"version"`
-	Status         Status   `json:"status"`
-	Process        *Process `json:"process"`
+	BpmnLiveStatus string      `json:"bpmnLiveStatus"`
+	StartTime      string      `json:"startTime"`
+	EndTime        string      `json:"endTime"`
+	InstanceKey    int64       `json:"instanceKey"`
+	ProcessKey     int64       `json:"processKey"`
+	Version        int64       `json:"version"`
+	Status         Status      `json:"status"`
+	Variables      []*Variable `json:"variables"`
+	Process        *Process    `json:"process"`
 }
 
 type MessageSubscription struct {
@@ -45,6 +47,13 @@ type Timer struct {
 	Repetitions        string `json:"repetitions"`
 	StartTime          string `json:"startTime"`
 	Status             Status `json:"status"`
+}
+
+type Variable struct {
+	ElementID int64  `json:"elementId"`
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	Time      string `json:"time"`
 }
 
 type Status string

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -33,11 +33,20 @@ type Process {
 type Instance {
   bpmnLiveStatus: String!
   startTime: DateTime!
+  endTime: DateTime!
   instanceKey: Int!
   processKey: Int!
   version: Int!
   status: Status!
+  variables: [Variable!]! @goField(forceResolver: true)
   process: Process! @goField(forceResolver: true)
+}
+
+type Variable {
+  elementId: Int!
+  name: String!
+  value: String!
+  time: DateTime!
 }
 
 type MessageSubscription {

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -13,7 +13,12 @@ import (
 
 // Variables is the resolver for the variables field.
 func (r *instanceResolver) Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error) {
-	panic(fmt.Errorf("not implemented: Variables - variables"))
+	dbVariables, err := r.Fetcher.GetVariablesForInstance(ctx, obj.InstanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch variables: %w", err)
+	}
+
+	return model.Map(dbVariables, model.FromStorageVariable), nil
 }
 
 // Process is the resolver for the process field.

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/graph/model"
 )
 
+// Variables is the resolver for the variables field.
+func (r *instanceResolver) Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error) {
+	panic(fmt.Errorf("not implemented: Variables - variables"))
+}
+
 // Process is the resolver for the process field.
 func (r *instanceResolver) Process(ctx context.Context, obj *model.Instance) (*model.Process, error) {
 	dbProcess, err := r.Fetcher.GetProcess(ctx, obj.ProcessKey)

--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -12,6 +12,7 @@ import (
 var migrations = []any{
 	&Process{},
 	&Instance{},
+	&Variable{},
 	&BpmnResource{},
 }
 

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -89,3 +89,14 @@ func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 
 	return processes, err
 }
+
+func (f *Fetcher) GetVariablesForInstance(ctx context.Context, instanceKey int64) ([]Variable, error) {
+	var variables []Variable
+	err := f.ContextDB(ctx).
+		Where(&Variable{ProcessInstanceKey: instanceKey}).
+		Order("time DESC").
+		Find(&variables).
+		Error
+
+	return variables, err
+}

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -6,11 +6,13 @@ import (
 
 // Instance model struct for the 'instances' database table.
 type Instance struct {
-	ProcessInstanceKey   int64     `gorm:"primarykey"`
-	ProcessDefinitionKey int64     `gorm:"not null"`
-	Version              int64     `gorm:"not null"`
-	Status               string    `gorm:"not null"`
-	StartTime            time.Time `gorm:"not null"`
+	ProcessInstanceKey   int64      `gorm:"primarykey"`
+	ProcessDefinitionKey int64      `gorm:"not null"`
+	Version              int64      `gorm:"not null"`
+	Status               string     `gorm:"not null"`
+	StartTime            time.Time  `gorm:"not null"`
+	EndTime              time.Time  `gorm:"not null"`
+	Variables            []Variable `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 }
 
 // Process model struct for the 'processes' database table.
@@ -21,6 +23,15 @@ type Process struct {
 	DeploymentTime       time.Time    `gorm:"not null"`
 	BpmnResource         BpmnResource `gorm:"foreignKey:BpmnProcessID;references:BpmnProcessID"`
 	Instances            []Instance   `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
+}
+
+// Variable model struct for the 'variables' database table.
+type Variable struct {
+	ElementID          int64     `gorm:"primarykey"`
+	ProcessInstanceKey int64     `gorm:"not null"`
+	Name               string    `gorm:"not null"`
+	Value              string    `gorm:"not null"`
+	Time               time.Time `gorm:"not null"`
 }
 
 // BpmnResource model struct for the 'bpmn_resources' database table.


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#126


### Description
<!-- Please add what is included in this pull request. -->
Added variables field and endTime to instances. Variables are backed by separate table.

Didn't have much time and this implements only the minimum requirements of the issue. Later issues can implement more.

Also tests are missing and should be added later. I did though validate that this works manually.

### Testing
<!-- How can code reviewers test this PR? -->
- Insert process, instance, and variable (see `backend/internal/storage/table.go` for reference on the structure)
- Validate that variable is returned through playground on only the assigned instance