### PR TITLE
fix(backend): variables table, testing, end time nullability

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -97,10 +97,9 @@ type ComplexityRoot struct {
 	}
 
 	Variable struct {
-		ElementID func(childComplexity int) int
-		Name      func(childComplexity int) int
-		Time      func(childComplexity int) int
-		Value     func(childComplexity int) int
+		Name  func(childComplexity int) int
+		Time  func(childComplexity int) int
+		Value func(childComplexity int) int
 	}
 }
 
@@ -382,13 +381,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Timer.Status(childComplexity), true
-
-	case "Variable.elementId":
-		if e.complexity.Variable.ElementID == nil {
-			break
-		}
-
-		return e.complexity.Variable.ElementID(childComplexity), true
 
 	case "Variable.name":
 		if e.complexity.Variable.Name == nil {
@@ -946,8 +938,6 @@ func (ec *executionContext) fieldContext_Instance_variables(ctx context.Context,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "elementId":
-				return ec.fieldContext_Variable_elementId(ctx, field)
 			case "name":
 				return ec.fieldContext_Variable_name(ctx, field)
 			case "value":
@@ -2355,50 +2345,6 @@ func (ec *executionContext) fieldContext_Timer_status(ctx context.Context, field
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Status does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Variable_elementId(ctx context.Context, field graphql.CollectedField, obj *model.Variable) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Variable_elementId(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ElementID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int64)
-	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Variable_elementId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Variable",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4924,11 +4870,6 @@ func (ec *executionContext) _Variable(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Variable")
-		case "elementId":
-			out.Values[i] = ec._Variable_elementId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "name":
 			out.Values[i] = ec._Variable_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -711,14 +711,11 @@ func (ec *executionContext) _Instance_endTime(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNDateTime2string(ctx, field.Selections, res)
+	return ec.marshalODateTime2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Instance_endTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4343,9 +4340,6 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "endTime":
 			out.Values[i] = ec._Instance_endTime(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "instanceKey":
 			out.Values[i] = ec._Instance_instanceKey(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -5919,6 +5913,22 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 		return graphql.Null
 	}
 	res := graphql.MarshalBoolean(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalODateTime2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalString(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalODateTime2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalString(*v)
 	return res
 }
 

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -36,7 +37,7 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
 		StartTime:      formatTime(instance.StartTime),
-		EndTime:        formatTime(instance.EndTime),
+		EndTime:        formatNullTime(instance.EndTime),
 		InstanceKey:    instance.ProcessInstanceKey,
 		ProcessKey:     instance.ProcessDefinitionKey,
 		Version:        instance.Version,
@@ -74,4 +75,14 @@ func FromStorageVariable(variable storage.Variable) *Variable {
 // Convert time to RFC3339 format.
 func formatTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
+}
+
+// Convert nullable time to RFC3339 format. Null times are converted to nil.
+func formatNullTime(nt sql.NullTime) *string {
+	if !nt.Valid {
+		return nil
+	}
+
+	t := formatTime(nt.Time)
+	return &t
 }

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -41,7 +41,8 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 		ProcessKey:     instance.ProcessDefinitionKey,
 		Version:        instance.Version,
 		Status:         status,
-		// Process has its own resolver and is not populated here.
+		// Variables and Process have their own resolvers and are not populated
+		// here.
 	}
 }
 
@@ -60,6 +61,7 @@ func FromStorageProcess(process storage.Process) *Process {
 	}
 }
 
+// Convert storage variable to GraphQL variable.
 func FromStorageVariable(variable storage.Variable) *Variable {
 	return &Variable{
 		ElementID: variable.ElementID,
@@ -69,6 +71,7 @@ func FromStorageVariable(variable storage.Variable) *Variable {
 	}
 }
 
+// Convert time to RFC3339 format.
 func formatTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -65,10 +65,9 @@ func FromStorageProcess(process storage.Process) *Process {
 // Convert storage variable to GraphQL variable.
 func FromStorageVariable(variable storage.Variable) *Variable {
 	return &Variable{
-		ElementID: variable.ElementID,
-		Name:      variable.Name,
-		Value:     variable.Value,
-		Time:      formatTime(variable.Time),
+		Name:  variable.Name,
+		Value: variable.Value,
+		Time:  formatTime(variable.Time),
 	}
 }
 

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -91,7 +91,55 @@ func TestFromStorageInstance(t *testing.T) {
 	}
 }
 
-func TestInvalidStatus(t *testing.T) {
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      any
+		expectedErr string
+		expected    Status
+	}{
+		{
+			name:     "Active",
+			status:   "ACTIVE",
+			expected: StatusActive,
+		},
+		{
+			name:     "Completed",
+			status:   "COMPLETED",
+			expected: StatusCompleted,
+		},
+		{
+			name:     "Terminated",
+			status:   "TERMINATED",
+			expected: StatusTerminated,
+		},
+		{
+			name:        "Invalid status",
+			status:      "INVALID_STATUS",
+			expectedErr: "INVALID_STATUS is not a valid Status",
+		},
+		{
+			name:        "Invalid type",
+			status:      1,
+			expectedErr: "enums must be strings",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actual Status
+			err := actual.UnmarshalGQL(test.status)
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+				return
+			}
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestStorageInstanceConversionPanic(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			assert.Fail(t, "expected panic")
@@ -99,7 +147,7 @@ func TestInvalidStatus(t *testing.T) {
 	}()
 
 	storageInstance := storage.Instance{
-		Status: "InvalidStatus",
+		Status: "INVALID_STATUS",
 	}
 
 	// Should panic.

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ func TestFromStorageBpmnResource(t *testing.T) {
 
 func TestFromStorageInstance(t *testing.T) {
 	now := time.Now()
+	nowFormatted := now.UTC().Format(time.RFC3339)
 
 	tests := []struct {
 		name            string
@@ -46,12 +48,12 @@ func TestFromStorageInstance(t *testing.T) {
 				Version:              1,
 				Status:               "ACTIVE",
 				StartTime:            now,
-				EndTime:              now,
+				EndTime:              sql.NullTime{},
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
-				StartTime:      now.UTC().Format(time.RFC3339),
-				EndTime:        now.UTC().Format(time.RFC3339),
+				StartTime:      nowFormatted,
+				EndTime:        nil,
 				InstanceKey:    10,
 				ProcessKey:     1,
 				Version:        1,
@@ -66,12 +68,12 @@ func TestFromStorageInstance(t *testing.T) {
 				Version:              2,
 				Status:               "COMPLETED",
 				StartTime:            now,
-				EndTime:              now,
+				EndTime:              sql.NullTime{Time: now, Valid: true},
 			},
 			expected: &Instance{
 				BpmnLiveStatus: "", // TODO
-				StartTime:      now.UTC().Format(time.RFC3339),
-				EndTime:        now.UTC().Format(time.RFC3339),
+				StartTime:      nowFormatted,
+				EndTime:        &nowFormatted,
 				InstanceKey:    20,
 				ProcessKey:     2,
 				Version:        2,

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -183,3 +183,23 @@ func TestFromStorageProcess(t *testing.T) {
 		})
 	}
 }
+
+func TestFromStorageVariable(t *testing.T) {
+	now := time.Now()
+
+	storageVariable := storage.Variable{
+		ProcessInstanceKey: 10,
+		Name:               "variable-name",
+		Value:              "variable-value",
+		Time:               now,
+	}
+	expected := &Variable{
+		Name:  "variable-name",
+		Value: "variable-value",
+		Time:  now.UTC().Format(time.RFC3339),
+	}
+
+	actual := FromStorageVariable(storageVariable)
+
+	assert.Equal(t, expected, actual)
+}

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -50,10 +50,9 @@ type Timer struct {
 }
 
 type Variable struct {
-	ElementID int64  `json:"elementId"`
-	Name      string `json:"name"`
-	Value     string `json:"value"`
-	Time      string `json:"time"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Time  string `json:"time"`
 }
 
 type Status string

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -11,7 +11,7 @@ import (
 type Instance struct {
 	BpmnLiveStatus string      `json:"bpmnLiveStatus"`
 	StartTime      string      `json:"startTime"`
-	EndTime        string      `json:"endTime"`
+	EndTime        *string     `json:"endTime,omitempty"`
 	InstanceKey    int64       `json:"instanceKey"`
 	ProcessKey     int64       `json:"processKey"`
 	Version        int64       `json:"version"`

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -58,18 +58,20 @@ type Variable struct {
 type Status string
 
 const (
-	StatusActive    Status = "ACTIVE"
-	StatusCompleted Status = "COMPLETED"
+	StatusActive     Status = "ACTIVE"
+	StatusCompleted  Status = "COMPLETED"
+	StatusTerminated Status = "TERMINATED"
 )
 
 var AllStatus = []Status{
 	StatusActive,
 	StatusCompleted,
+	StatusTerminated,
 }
 
 func (e Status) IsValid() bool {
 	switch e {
-	case StatusActive, StatusCompleted:
+	case StatusActive, StatusCompleted, StatusTerminated:
 		return true
 	}
 	return false

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -66,6 +66,7 @@ type Timer {
 enum Status {
   ACTIVE
   COMPLETED
+  TERMINATED
 }
 
 # The `DateTime` scalar type represents a date and time following the

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -43,7 +43,6 @@ type Instance {
 }
 
 type Variable {
-  elementId: Int!
   name: String!
   value: String!
   time: DateTime!

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -33,7 +33,7 @@ type Process {
 type Instance {
   bpmnLiveStatus: String!
   startTime: DateTime!
-  endTime: DateTime!
+  endTime: DateTime
   instanceKey: Int!
   processKey: Int!
   version: Int!

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -24,6 +24,7 @@ func (f *Fetcher) ContextDB(ctx context.Context) *gorm.DB {
 	return f.db.WithContext(ctx)
 }
 
+// Gets a BPMN resource by its process ID.
 func (f *Fetcher) GetBpmnResource(ctx context.Context, bpmnProcessID string) (BpmnResource, error) {
 	var bpmnResource BpmnResource
 	err := f.ContextDB(ctx).
@@ -90,6 +91,7 @@ func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 	return processes, err
 }
 
+// Gets all variables for an instance.
 func (f *Fetcher) GetVariablesForInstance(ctx context.Context, instanceKey int64) ([]Variable, error) {
 	var variables []Variable
 	err := f.ContextDB(ctx).

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -28,9 +28,8 @@ type Process struct {
 
 // Variable model struct for the 'variables' database table.
 type Variable struct {
-	ElementID          int64     `gorm:"primarykey"`
-	ProcessInstanceKey int64     `gorm:"not null"`
-	Name               string    `gorm:"not null"`
+	ProcessInstanceKey int64     `gorm:"primarykey;autoIncrement:false"`
+	Name               string    `gorm:"primarykey"`
 	Value              string    `gorm:"not null"`
 	Time               time.Time `gorm:"not null"`
 }

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -1,17 +1,18 @@
 package storage
 
 import (
+	"database/sql"
 	"time"
 )
 
 // Instance model struct for the 'instances' database table.
 type Instance struct {
-	ProcessInstanceKey   int64      `gorm:"primarykey"`
-	ProcessDefinitionKey int64      `gorm:"not null"`
-	Version              int64      `gorm:"not null"`
-	Status               string     `gorm:"not null"`
-	StartTime            time.Time  `gorm:"not null"`
-	EndTime              time.Time  `gorm:"not null"`
+	ProcessInstanceKey   int64     `gorm:"primarykey"`
+	ProcessDefinitionKey int64     `gorm:"not null"`
+	Version              int64     `gorm:"not null"`
+	Status               string    `gorm:"not null"`
+	StartTime            time.Time `gorm:"not null"`
+	EndTime              sql.NullTime
 	Variables            []Variable `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 }
 


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#126

### Description
<!-- Please add what is included in this pull request. -->
Previous PR #240 was done with some oversights and left out testing. This PR supplements that and makes some changes:
- Made `endTime` for instances nullable throughout (DB and GraphQL API). `ACTIVE` instances would have null `endTime`.
- Removed `ElementID` from variables table and made `ProcessInstanceKey` and variable `Name` into composite key.
- Added `TERMINATED` status.
- Added missing tests for added components.

### Testing
<!-- How can code reviewers test this PR? -->
Remember to `docker compose down --volumes` before testing, to ensure migration causes no problems.

- Insert process, instance, and variables for that instance.
- Validate that variables are returned for correct instances in API playground.
- Validate that `TERMINATED` status shows up correctly, and doesn't cause `Internal system error`.