### PR TITLE
feat(backend): add instance job query endpoint

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -52,12 +52,23 @@ type ComplexityRoot struct {
 		BpmnLiveStatus func(childComplexity int) int
 		EndTime        func(childComplexity int) int
 		InstanceKey    func(childComplexity int) int
+		Jobs           func(childComplexity int) int
 		Process        func(childComplexity int) int
 		ProcessKey     func(childComplexity int) int
 		StartTime      func(childComplexity int) int
 		Status         func(childComplexity int) int
 		Variables      func(childComplexity int) int
 		Version        func(childComplexity int) int
+	}
+
+	Job struct {
+		ElementID func(childComplexity int) int
+		Key       func(childComplexity int) int
+		Retries   func(childComplexity int) int
+		State     func(childComplexity int) int
+		Time      func(childComplexity int) int
+		Type      func(childComplexity int) int
+		Worker    func(childComplexity int) int
 	}
 
 	MessageSubscription struct {
@@ -104,6 +115,7 @@ type ComplexityRoot struct {
 }
 
 type InstanceResolver interface {
+	Jobs(ctx context.Context, obj *model.Instance) ([]*model.Job, error)
 	Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error)
 	Process(ctx context.Context, obj *model.Instance) (*model.Process, error)
 }
@@ -162,6 +174,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Instance.InstanceKey(childComplexity), true
 
+	case "Instance.jobs":
+		if e.complexity.Instance.Jobs == nil {
+			break
+		}
+
+		return e.complexity.Instance.Jobs(childComplexity), true
+
 	case "Instance.process":
 		if e.complexity.Instance.Process == nil {
 			break
@@ -203,6 +222,55 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Instance.Version(childComplexity), true
+
+	case "Job.elementId":
+		if e.complexity.Job.ElementID == nil {
+			break
+		}
+
+		return e.complexity.Job.ElementID(childComplexity), true
+
+	case "Job.key":
+		if e.complexity.Job.Key == nil {
+			break
+		}
+
+		return e.complexity.Job.Key(childComplexity), true
+
+	case "Job.retries":
+		if e.complexity.Job.Retries == nil {
+			break
+		}
+
+		return e.complexity.Job.Retries(childComplexity), true
+
+	case "Job.state":
+		if e.complexity.Job.State == nil {
+			break
+		}
+
+		return e.complexity.Job.State(childComplexity), true
+
+	case "Job.time":
+		if e.complexity.Job.Time == nil {
+			break
+		}
+
+		return e.complexity.Job.Time(childComplexity), true
+
+	case "Job.type":
+		if e.complexity.Job.Type == nil {
+			break
+		}
+
+		return e.complexity.Job.Type(childComplexity), true
+
+	case "Job.worker":
+		if e.complexity.Job.Worker == nil {
+			break
+		}
+
+		return e.complexity.Job.Worker(childComplexity), true
 
 	case "MessageSubscription.createdAt":
 		if e.complexity.MessageSubscription.CreatedAt == nil {
@@ -899,6 +967,66 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Instance_jobs(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_jobs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Instance().Jobs(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Job)
+	fc.Result = res
+	return ec.marshalNJob2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐJobᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_jobs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "elementId":
+				return ec.fieldContext_Job_elementId(ctx, field)
+			case "key":
+				return ec.fieldContext_Job_key(ctx, field)
+			case "type":
+				return ec.fieldContext_Job_type(ctx, field)
+			case "retries":
+				return ec.fieldContext_Job_retries(ctx, field)
+			case "worker":
+				return ec.fieldContext_Job_worker(ctx, field)
+			case "state":
+				return ec.fieldContext_Job_state(ctx, field)
+			case "time":
+				return ec.fieldContext_Job_time(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Job", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Instance_variables(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Instance_variables(ctx, field)
 	if err != nil {
@@ -1014,6 +1142,314 @@ func (ec *executionContext) fieldContext_Instance_process(ctx context.Context, f
 				return ec.fieldContext_Process_version(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_elementId(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_elementId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ElementID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_elementId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_key(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_type(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_retries(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_retries(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Retries, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_retries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_worker(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_worker(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Worker, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_worker(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_state(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_state(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_state(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Job_time(ctx context.Context, field graphql.CollectedField, obj *model.Job) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Job_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Time, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNDateTime2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Job_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Job",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DateTime does not have child fields")
 		},
 	}
 	return fc, nil
@@ -1512,6 +1948,8 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "jobs":
+				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
 				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
@@ -1918,6 +2356,8 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "jobs":
+				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
 				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
@@ -1979,6 +2419,8 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "jobs":
+				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
 				return ec.fieldContext_Instance_variables(ctx, field)
 			case "process":
@@ -4306,6 +4748,42 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "jobs":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Instance_jobs(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "variables":
 			field := field
 
@@ -4378,6 +4856,75 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var jobImplementors = []string{"Job"}
+
+func (ec *executionContext) _Job(ctx context.Context, sel ast.SelectionSet, obj *model.Job) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, jobImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Job")
+		case "elementId":
+			out.Values[i] = ec._Job_elementId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "key":
+			out.Values[i] = ec._Job_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "type":
+			out.Values[i] = ec._Job_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "retries":
+			out.Values[i] = ec._Job_retries(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "worker":
+			out.Values[i] = ec._Job_worker(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "state":
+			out.Values[i] = ec._Job_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "time":
+			out.Values[i] = ec._Job_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -5331,6 +5878,60 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNJob2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐJobᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Job) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNJob2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐJob(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNJob2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐJob(ctx context.Context, sel ast.SelectionSet, v *model.Job) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Job(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNMessageSubscription2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐMessageSubscriptionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.MessageSubscription) graphql.Marshaler {

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -62,6 +62,7 @@ func FromStorageProcess(process storage.Process) *Process {
 	}
 }
 
+// Convert storage job to GraphQL job.
 func FromStorageJob(job storage.Job) *Job {
 	return &Job{
 		ElementID: job.ElementID,

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -62,6 +62,18 @@ func FromStorageProcess(process storage.Process) *Process {
 	}
 }
 
+func FromStorageJob(job storage.Job) *Job {
+	return &Job{
+		ElementID: job.ElementID,
+		Key:       job.Key,
+		Type:      job.Type,
+		Retries:   job.Retries,
+		Worker:    job.Worker,
+		State:     job.State,
+		Time:      formatTime(job.Time),
+	}
+}
+
 // Convert storage variable to GraphQL variable.
 func FromStorageVariable(variable storage.Variable) *Variable {
 	return &Variable{

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -16,8 +16,19 @@ type Instance struct {
 	ProcessKey     int64       `json:"processKey"`
 	Version        int64       `json:"version"`
 	Status         Status      `json:"status"`
+	Jobs           []*Job      `json:"jobs"`
 	Variables      []*Variable `json:"variables"`
 	Process        *Process    `json:"process"`
+}
+
+type Job struct {
+	ElementID string `json:"elementId"`
+	Key       int64  `json:"key"`
+	Type      string `json:"type"`
+	Retries   int64  `json:"retries"`
+	Worker    string `json:"worker"`
+	State     string `json:"state"`
+	Time      string `json:"time"`
 }
 
 type MessageSubscription struct {

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -38,8 +38,19 @@ type Instance {
   processKey: Int!
   version: Int!
   status: Status!
+  jobs: [Job!]! @goField(forceResolver: true)
   variables: [Variable!]! @goField(forceResolver: true)
   process: Process! @goField(forceResolver: true)
+}
+
+type Job {
+  elementId: String!
+  key: Int!
+  type: String!
+  retries: Int!
+  worker: String!
+  state: String!
+  time: DateTime!
 }
 
 type Variable {

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -11,6 +11,16 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/graph/model"
 )
 
+// Jobs is the resolver for the jobs field.
+func (r *instanceResolver) Jobs(ctx context.Context, obj *model.Instance) ([]*model.Job, error) {
+	dbJobs, err := r.Fetcher.GetJobsForInstance(ctx, obj.InstanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch jobs: %w", err)
+	}
+
+	return model.Map(dbJobs, model.FromStorageJob), nil
+}
+
 // Variables is the resolver for the variables field.
 func (r *instanceResolver) Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error) {
 	dbVariables, err := r.Fetcher.GetVariablesForInstance(ctx, obj.InstanceKey)

--- a/backend/internal/storage/database.go
+++ b/backend/internal/storage/database.go
@@ -8,14 +8,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// List of migrations to be run on database during initialization.
-var migrations = []any{
-	&Process{},
-	&Instance{},
-	&Variable{},
-	&BpmnResource{},
-}
-
 // Configuration to connect to database.
 type DsnConfig struct {
 	// Username used to log in to the database.
@@ -58,7 +50,7 @@ func ConnectDb(dsnConfig DsnConfig, maxRetries int, retryDelay time.Duration) (*
 
 // Migrate all tables in database automatically.
 func AutoMigrate(db *gorm.DB) error {
-	if err := db.AutoMigrate(migrations...); err != nil {
+	if err := db.AutoMigrate(TableMigrations...); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -91,6 +91,17 @@ func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 	return processes, err
 }
 
+func (f *Fetcher) GetJobsForInstance(ctx context.Context, instanceKey int64) ([]Job, error) {
+	var jobs []Job
+	err := f.ContextDB(ctx).
+		Where(&Job{ProcessInstanceKey: instanceKey}).
+		Order("time DESC").
+		Find(&jobs).
+		Error
+
+	return jobs, err
+}
+
 // Gets all variables for an instance.
 func (f *Fetcher) GetVariablesForInstance(ctx context.Context, instanceKey int64) ([]Variable, error) {
 	var variables []Variable

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -91,6 +91,7 @@ func (f *Fetcher) GetProcesses(ctx context.Context) ([]Process, error) {
 	return processes, err
 }
 
+// Gets all jobs for an instance.
 func (f *Fetcher) GetJobsForInstance(ctx context.Context, instanceKey int64) ([]Job, error) {
 	var jobs []Job
 	err := f.ContextDB(ctx).

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -5,6 +5,15 @@ import (
 	"time"
 )
 
+// List of migrations to be run on database during initialization.
+var TableMigrations = []any{
+	&Process{},
+	&Instance{},
+	&Job{},
+	&Variable{},
+	&BpmnResource{},
+}
+
 // Instance model struct for the 'instances' database table.
 type Instance struct {
 	ProcessInstanceKey   int64     `gorm:"primarykey"`
@@ -13,6 +22,7 @@ type Instance struct {
 	Status               string    `gorm:"not null"`
 	StartTime            time.Time `gorm:"not null"`
 	EndTime              sql.NullTime
+	Jobs                 []Job      `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 	Variables            []Variable `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 }
 
@@ -24,6 +34,18 @@ type Process struct {
 	DeploymentTime       time.Time    `gorm:"not null"`
 	BpmnResource         BpmnResource `gorm:"foreignKey:BpmnProcessID;references:BpmnProcessID"`
 	Instances            []Instance   `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
+}
+
+// Job model struct for the 'jobs' database table.
+type Job struct {
+	Key                int64     `gorm:"primarykey"`
+	ElementID          string    `gorm:"not null"`
+	ProcessInstanceKey int64     `gorm:"not null"`
+	Type               string    `gorm:"not null"`
+	Retries            int64     `gorm:"not null"`
+	Worker             string    `gorm:"not null"`
+	State              string    `gorm:"not null"`
+	Time               time.Time `gorm:"not null"`
 }
 
 // Variable model struct for the 'variables' database table.

--- a/backend/test/data/fill_db.sql
+++ b/backend/test/data/fill_db.sql
@@ -16,6 +16,11 @@ VALUES(11, 'a', '1', '2023-11-27T02:05:00Z');
 INSERT INTO variables(process_instance_key, name, value, time)
 VALUES(11, 'b', '2', '2023-11-27T02:22:00Z');
 
+INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, state, time)
+VALUES(11, 'some-element-1', 100, 'big-job', 4, 'big-boy-1', 'WORKING', '2023-11-27T02:23:00Z');
+INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, state, time)
+VALUES(11, 'some-element-2', 101, 'big-job', 2, 'big-boy-1', 'WORKING', '2023-11-27T02:24:00Z');
+
 INSERT INTO variables(process_instance_key, name, value, time)
 VALUES(12, 'foo', 'bar', '2023-11-27T02:30:00Z');
 INSERT INTO variables(process_instance_key, name, value, time)


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
More implementation for ducanhpham0312/zeevision-private#126

### Description
<!-- Please add what is included in this pull request. -->
Added instance specific query endpoint for jobs, and table to store the jobs.

### Testing
<!-- How can code reviewers test this PR? -->
- Start test bench and zeevision with volume wiped.
- Use `fill_db.sql` to fill database from pgAdmin.
- Validate that jobs query for instances works.