### PR TITLE
feat(backend): add incidents query endpoints

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -54,8 +54,9 @@ type ComplexityRoot struct {
 		ElementID    func(childComplexity int) int
 		ErrorMessage func(childComplexity int) int
 		ErrorType    func(childComplexity int) int
+		IncidentKey  func(childComplexity int) int
 		Instance     func(childComplexity int) int
-		Key          func(childComplexity int) int
+		InstanceKey  func(childComplexity int) int
 		State        func(childComplexity int) int
 		Time         func(childComplexity int) int
 	}
@@ -180,6 +181,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Incident.ErrorType(childComplexity), true
 
+	case "Incident.incidentKey":
+		if e.complexity.Incident.IncidentKey == nil {
+			break
+		}
+
+		return e.complexity.Incident.IncidentKey(childComplexity), true
+
 	case "Incident.instance":
 		if e.complexity.Incident.Instance == nil {
 			break
@@ -187,12 +195,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Incident.Instance(childComplexity), true
 
-	case "Incident.key":
-		if e.complexity.Incident.Key == nil {
+	case "Incident.instanceKey":
+		if e.complexity.Incident.InstanceKey == nil {
 			break
 		}
 
-		return e.complexity.Incident.Key(childComplexity), true
+		return e.complexity.Incident.InstanceKey(childComplexity), true
 
 	case "Incident.state":
 		if e.complexity.Incident.State == nil {
@@ -675,8 +683,8 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _Incident_key(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Incident_key(ctx, field)
+func (ec *executionContext) _Incident_incidentKey(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_incidentKey(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -689,7 +697,7 @@ func (ec *executionContext) _Incident_key(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Key, nil
+		return obj.IncidentKey, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -706,7 +714,51 @@ func (ec *executionContext) _Incident_key(ctx context.Context, field graphql.Col
 	return ec.marshalNInt2int64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Incident_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Incident_incidentKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_instanceKey(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_instanceKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InstanceKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_instanceKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Incident",
 		Field:      field,
@@ -1351,8 +1403,10 @@ func (ec *executionContext) fieldContext_Instance_incidents(ctx context.Context,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "key":
-				return ec.fieldContext_Incident_key(ctx, field)
+			case "incidentKey":
+				return ec.fieldContext_Incident_incidentKey(ctx, field)
+			case "instanceKey":
+				return ec.fieldContext_Incident_instanceKey(ctx, field)
 			case "elementId":
 				return ec.fieldContext_Incident_elementId(ctx, field)
 			case "errorType":
@@ -2711,8 +2765,10 @@ func (ec *executionContext) fieldContext_Query_incidents(ctx context.Context, fi
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "key":
-				return ec.fieldContext_Incident_key(ctx, field)
+			case "incidentKey":
+				return ec.fieldContext_Incident_incidentKey(ctx, field)
+			case "instanceKey":
+				return ec.fieldContext_Incident_instanceKey(ctx, field)
 			case "elementId":
 				return ec.fieldContext_Incident_elementId(ctx, field)
 			case "errorType":
@@ -4849,8 +4905,13 @@ func (ec *executionContext) _Incident(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Incident")
-		case "key":
-			out.Values[i] = ec._Incident_key(ctx, field, obj)
+		case "incidentKey":
+			out.Values[i] = ec._Incident_incidentKey(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "instanceKey":
+			out.Values[i] = ec._Incident_instanceKey(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -39,6 +39,7 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Incident() IncidentResolver
 	Instance() InstanceResolver
 	Job() JobResolver
 	Process() ProcessResolver
@@ -49,9 +50,20 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	Incident struct {
+		ElementID    func(childComplexity int) int
+		ErrorMessage func(childComplexity int) int
+		ErrorType    func(childComplexity int) int
+		Instance     func(childComplexity int) int
+		Key          func(childComplexity int) int
+		State        func(childComplexity int) int
+		Time         func(childComplexity int) int
+	}
+
 	Instance struct {
 		BpmnLiveStatus func(childComplexity int) int
 		EndTime        func(childComplexity int) int
+		Incidents      func(childComplexity int) int
 		InstanceKey    func(childComplexity int) int
 		Jobs           func(childComplexity int) int
 		Process        func(childComplexity int) int
@@ -87,6 +99,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		Incidents func(childComplexity int) int
 		Instance  func(childComplexity int, instanceKey int64) int
 		Instances func(childComplexity int) int
 		Jobs      func(childComplexity int) int
@@ -101,7 +114,11 @@ type ComplexityRoot struct {
 	}
 }
 
+type IncidentResolver interface {
+	Instance(ctx context.Context, obj *model.Incident) (*model.Instance, error)
+}
 type InstanceResolver interface {
+	Incidents(ctx context.Context, obj *model.Instance) ([]*model.Incident, error)
 	Jobs(ctx context.Context, obj *model.Instance) ([]*model.Job, error)
 	Variables(ctx context.Context, obj *model.Instance) ([]*model.Variable, error)
 	Process(ctx context.Context, obj *model.Instance) (*model.Process, error)
@@ -119,6 +136,7 @@ type QueryResolver interface {
 	Process(ctx context.Context, processKey int64) (*model.Process, error)
 	Instances(ctx context.Context) ([]*model.Instance, error)
 	Instance(ctx context.Context, instanceKey int64) (*model.Instance, error)
+	Incidents(ctx context.Context) ([]*model.Incident, error)
 	Jobs(ctx context.Context) ([]*model.Job, error)
 }
 
@@ -141,6 +159,55 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
+	case "Incident.elementId":
+		if e.complexity.Incident.ElementID == nil {
+			break
+		}
+
+		return e.complexity.Incident.ElementID(childComplexity), true
+
+	case "Incident.errorMessage":
+		if e.complexity.Incident.ErrorMessage == nil {
+			break
+		}
+
+		return e.complexity.Incident.ErrorMessage(childComplexity), true
+
+	case "Incident.errorType":
+		if e.complexity.Incident.ErrorType == nil {
+			break
+		}
+
+		return e.complexity.Incident.ErrorType(childComplexity), true
+
+	case "Incident.instance":
+		if e.complexity.Incident.Instance == nil {
+			break
+		}
+
+		return e.complexity.Incident.Instance(childComplexity), true
+
+	case "Incident.key":
+		if e.complexity.Incident.Key == nil {
+			break
+		}
+
+		return e.complexity.Incident.Key(childComplexity), true
+
+	case "Incident.state":
+		if e.complexity.Incident.State == nil {
+			break
+		}
+
+		return e.complexity.Incident.State(childComplexity), true
+
+	case "Incident.time":
+		if e.complexity.Incident.Time == nil {
+			break
+		}
+
+		return e.complexity.Incident.Time(childComplexity), true
+
 	case "Instance.bpmnLiveStatus":
 		if e.complexity.Instance.BpmnLiveStatus == nil {
 			break
@@ -154,6 +221,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Instance.EndTime(childComplexity), true
+
+	case "Instance.incidents":
+		if e.complexity.Instance.Incidents == nil {
+			break
+		}
+
+		return e.complexity.Instance.Incidents(childComplexity), true
 
 	case "Instance.instanceKey":
 		if e.complexity.Instance.InstanceKey == nil {
@@ -336,6 +410,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Process.Version(childComplexity), true
+
+	case "Query.incidents":
+		if e.complexity.Query.Incidents == nil {
+			break
+		}
+
+		return e.complexity.Query.Incidents(childComplexity), true
 
 	case "Query.instance":
 		if e.complexity.Query.Instance == nil {
@@ -593,6 +674,338 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _Incident_key(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_elementId(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_elementId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ElementID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_elementId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_errorType(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_errorType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_errorType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_errorMessage(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_errorMessage(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorMessage, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_errorMessage(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_state(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_state(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_state(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_time(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Time, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNDateTime2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DateTime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Incident_instance(ctx context.Context, field graphql.CollectedField, obj *model.Incident) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Incident_instance(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Incident().Instance(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Instance)
+	fc.Result = res
+	return ec.marshalNInstance2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐInstance(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Incident_instance(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Incident",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "bpmnLiveStatus":
+				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
+			case "startTime":
+				return ec.fieldContext_Instance_startTime(ctx, field)
+			case "endTime":
+				return ec.fieldContext_Instance_endTime(ctx, field)
+			case "instanceKey":
+				return ec.fieldContext_Instance_instanceKey(ctx, field)
+			case "processKey":
+				return ec.fieldContext_Instance_processKey(ctx, field)
+			case "version":
+				return ec.fieldContext_Instance_version(ctx, field)
+			case "status":
+				return ec.fieldContext_Instance_status(ctx, field)
+			case "incidents":
+				return ec.fieldContext_Instance_incidents(ctx, field)
+			case "jobs":
+				return ec.fieldContext_Instance_jobs(ctx, field)
+			case "variables":
+				return ec.fieldContext_Instance_variables(ctx, field)
+			case "process":
+				return ec.fieldContext_Instance_process(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Instance", field.Name)
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Instance_bpmnLiveStatus(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
@@ -894,6 +1307,66 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Status does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Instance_incidents(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Instance_incidents(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Instance().Incidents(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Incident)
+	fc.Result = res
+	return ec.marshalNIncident2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐIncidentᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Instance_incidents(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Instance",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_Incident_key(ctx, field)
+			case "elementId":
+				return ec.fieldContext_Incident_elementId(ctx, field)
+			case "errorType":
+				return ec.fieldContext_Incident_errorType(ctx, field)
+			case "errorMessage":
+				return ec.fieldContext_Incident_errorMessage(ctx, field)
+			case "state":
+				return ec.fieldContext_Incident_state(ctx, field)
+			case "time":
+				return ec.fieldContext_Incident_time(ctx, field)
+			case "instance":
+				return ec.fieldContext_Incident_instance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Incident", field.Name)
 		},
 	}
 	return fc, nil
@@ -1484,6 +1957,8 @@ func (ec *executionContext) fieldContext_Job_instance(ctx context.Context, field
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "incidents":
+				return ec.fieldContext_Instance_incidents(ctx, field)
 			case "jobs":
 				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
@@ -1814,6 +2289,8 @@ func (ec *executionContext) fieldContext_Process_instances(ctx context.Context, 
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "incidents":
+				return ec.fieldContext_Instance_incidents(ctx, field)
 			case "jobs":
 				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
@@ -2104,6 +2581,8 @@ func (ec *executionContext) fieldContext_Query_instances(ctx context.Context, fi
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "incidents":
+				return ec.fieldContext_Instance_incidents(ctx, field)
 			case "jobs":
 				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
@@ -2167,6 +2646,8 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 				return ec.fieldContext_Instance_version(ctx, field)
 			case "status":
 				return ec.fieldContext_Instance_status(ctx, field)
+			case "incidents":
+				return ec.fieldContext_Instance_incidents(ctx, field)
 			case "jobs":
 				return ec.fieldContext_Instance_jobs(ctx, field)
 			case "variables":
@@ -2187,6 +2668,66 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 	if fc.Args, err = ec.field_Query_instance_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_incidents(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_incidents(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Incidents(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Incident)
+	fc.Result = res
+	return ec.marshalNIncident2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐIncidentᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_incidents(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_Incident_key(ctx, field)
+			case "elementId":
+				return ec.fieldContext_Incident_elementId(ctx, field)
+			case "errorType":
+				return ec.fieldContext_Incident_errorType(ctx, field)
+			case "errorMessage":
+				return ec.fieldContext_Incident_errorMessage(ctx, field)
+			case "state":
+				return ec.fieldContext_Incident_state(ctx, field)
+			case "time":
+				return ec.fieldContext_Incident_time(ctx, field)
+			case "instance":
+				return ec.fieldContext_Incident_instance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Incident", field.Name)
+		},
 	}
 	return fc, nil
 }
@@ -4297,6 +4838,106 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 
 // region    **************************** object.gotpl ****************************
 
+var incidentImplementors = []string{"Incident"}
+
+func (ec *executionContext) _Incident(ctx context.Context, sel ast.SelectionSet, obj *model.Incident) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, incidentImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Incident")
+		case "key":
+			out.Values[i] = ec._Incident_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "elementId":
+			out.Values[i] = ec._Incident_elementId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "errorType":
+			out.Values[i] = ec._Incident_errorType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "errorMessage":
+			out.Values[i] = ec._Incident_errorMessage(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "state":
+			out.Values[i] = ec._Incident_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "time":
+			out.Values[i] = ec._Incident_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "instance":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Incident_instance(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var instanceImplementors = []string{"Instance"}
 
 func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet, obj *model.Instance) graphql.Marshaler {
@@ -4340,6 +4981,42 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "incidents":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Instance_incidents(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "jobs":
 			field := field
 
@@ -4823,6 +5500,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "incidents":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_incidents(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "jobs":
 			field := field
 
@@ -5279,6 +5978,60 @@ func (ec *executionContext) marshalNDateTime2string(ctx context.Context, sel ast
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNIncident2ᚕᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐIncidentᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Incident) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNIncident2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐIncident(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNIncident2ᚖgithubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐIncident(ctx context.Context, sel ast.SelectionSet, v *model.Incident) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Incident(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNInstance2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐInstance(ctx context.Context, sel ast.SelectionSet, v model.Instance) graphql.Marshaler {

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -62,6 +62,7 @@ func FromStorageProcess(process storage.Process) *Process {
 	}
 }
 
+// Convert storage incident to GraphQL incident.
 func FromStorageIncident(incident storage.Incident) *Incident {
 	return &Incident{
 		IncidentKey:  incident.Key,

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -62,6 +62,19 @@ func FromStorageProcess(process storage.Process) *Process {
 	}
 }
 
+func FromStorageIncident(incident storage.Incident) *Incident {
+	return &Incident{
+		IncidentKey:  incident.Key,
+		InstanceKey:  incident.ProcessInstanceKey,
+		ElementID:    incident.ElementID,
+		ErrorType:    incident.ErrorType,
+		ErrorMessage: incident.ErrorMessage,
+		State:        incident.State,
+		Time:         formatTime(incident.Time),
+		// Instance is populated by the Instance resolver.
+	}
+}
+
 // Convert storage job to GraphQL job.
 func FromStorageJob(job storage.Job) *Job {
 	return &Job{

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -232,6 +232,33 @@ func TestFromStorageProcess(t *testing.T) {
 	}
 }
 
+func TestFromStrorageIncident(t *testing.T) {
+	now := time.Now()
+
+	storageIncident := storage.Incident{
+		Key:                10,
+		ProcessInstanceKey: 100,
+		ElementID:          "element-id",
+		ErrorType:          "error-type",
+		ErrorMessage:       "error-message",
+		State:              "state",
+		Time:               now,
+	}
+	expected := &Incident{
+		IncidentKey:  10,
+		InstanceKey:  100,
+		ElementID:    "element-id",
+		ErrorType:    "error-type",
+		ErrorMessage: "error-message",
+		State:        "state",
+		Time:         now.UTC().Format(time.RFC3339),
+	}
+
+	actual := FromStorageIncident(storageIncident)
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestFromStorageJob(t *testing.T) {
 	now := time.Now()
 

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -8,6 +8,16 @@ import (
 	"strconv"
 )
 
+type Incident struct {
+	Key          int64     `json:"key"`
+	ElementID    string    `json:"elementId"`
+	ErrorType    string    `json:"errorType"`
+	ErrorMessage string    `json:"errorMessage"`
+	State        string    `json:"state"`
+	Time         string    `json:"time"`
+	Instance     *Instance `json:"instance"`
+}
+
 type Instance struct {
 	BpmnLiveStatus string      `json:"bpmnLiveStatus"`
 	StartTime      string      `json:"startTime"`
@@ -16,6 +26,7 @@ type Instance struct {
 	ProcessKey     int64       `json:"processKey"`
 	Version        int64       `json:"version"`
 	Status         Status      `json:"status"`
+	Incidents      []*Incident `json:"incidents"`
 	Jobs           []*Job      `json:"jobs"`
 	Variables      []*Variable `json:"variables"`
 	Process        *Process    `json:"process"`

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Incident struct {
-	Key          int64     `json:"key"`
+	IncidentKey  int64     `json:"incidentKey"`
+	InstanceKey  int64     `json:"instanceKey"`
 	ElementID    string    `json:"elementId"`
 	ErrorType    string    `json:"errorType"`
 	ErrorMessage string    `json:"errorMessage"`

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -14,6 +14,7 @@ type Query {
   process(processKey: Int!): Process
   instances: [Instance!]!
   instance(instanceKey: Int!): Instance
+  incidents: [Incident!]!
   jobs: [Job!]!
 }
 
@@ -37,9 +38,20 @@ type Instance {
   processKey: Int!
   version: Int!
   status: Status!
+  incidents: [Incident!]! @goField(forceResolver: true)
   jobs: [Job!]! @goField(forceResolver: true)
   variables: [Variable!]! @goField(forceResolver: true)
   process: Process! @goField(forceResolver: true)
+}
+
+type Incident {
+  key: Int!
+  elementId: String!
+  errorType: String!
+  errorMessage: String!
+  state: String!
+  time: DateTime!
+  instance: Instance! @goField(forceResolver: true)
 }
 
 type Job {

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -45,7 +45,8 @@ type Instance {
 }
 
 type Incident {
-  key: Int!
+  incidentKey: Int!
+  instanceKey: Int!
   elementId: String!
   errorType: String!
   errorMessage: String!

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -13,12 +13,22 @@ import (
 
 // Instance is the resolver for the instance field.
 func (r *incidentResolver) Instance(ctx context.Context, obj *model.Incident) (*model.Instance, error) {
-	panic(fmt.Errorf("not implemented: Instance - instance"))
+	dbInstance, err := r.Fetcher.GetInstance(ctx, obj.InstanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch instance: %w", err)
+	}
+
+	return model.FromStorageInstance(dbInstance), nil
 }
 
 // Incidents is the resolver for the incidents field.
 func (r *instanceResolver) Incidents(ctx context.Context, obj *model.Instance) ([]*model.Incident, error) {
-	panic(fmt.Errorf("not implemented: Incidents - incidents"))
+	dbIncidents, err := r.Fetcher.GetIncidentsForInstance(ctx, obj.InstanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch incidents: %w", err)
+	}
+
+	return model.Map(dbIncidents, model.FromStorageIncident), nil
 }
 
 // Jobs is the resolver for the jobs field.
@@ -123,7 +133,12 @@ func (r *queryResolver) Instance(ctx context.Context, instanceKey int64) (*model
 
 // Incidents is the resolver for the incidents field.
 func (r *queryResolver) Incidents(ctx context.Context) ([]*model.Incident, error) {
-	panic(fmt.Errorf("not implemented: Incidents - incidents"))
+	dbIncidents, err := r.Fetcher.GetIncidents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch incidents: %w", err)
+	}
+
+	return model.Map(dbIncidents, model.FromStorageIncident), nil
 }
 
 // Jobs is the resolver for the jobs field.

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -11,6 +11,16 @@ import (
 	"github.com/ducanhpham0312/zeevision/backend/graph/model"
 )
 
+// Instance is the resolver for the instance field.
+func (r *incidentResolver) Instance(ctx context.Context, obj *model.Incident) (*model.Instance, error) {
+	panic(fmt.Errorf("not implemented: Instance - instance"))
+}
+
+// Incidents is the resolver for the incidents field.
+func (r *instanceResolver) Incidents(ctx context.Context, obj *model.Instance) ([]*model.Incident, error) {
+	panic(fmt.Errorf("not implemented: Incidents - incidents"))
+}
+
 // Jobs is the resolver for the jobs field.
 func (r *instanceResolver) Jobs(ctx context.Context, obj *model.Instance) ([]*model.Job, error) {
 	dbJobs, err := r.Fetcher.GetJobsForInstance(ctx, obj.InstanceKey)
@@ -111,6 +121,11 @@ func (r *queryResolver) Instance(ctx context.Context, instanceKey int64) (*model
 	return model.FromStorageInstance(dbInstance), nil
 }
 
+// Incidents is the resolver for the incidents field.
+func (r *queryResolver) Incidents(ctx context.Context) ([]*model.Incident, error) {
+	panic(fmt.Errorf("not implemented: Incidents - incidents"))
+}
+
 // Jobs is the resolver for the jobs field.
 func (r *queryResolver) Jobs(ctx context.Context) ([]*model.Job, error) {
 	dbJobs, err := r.Fetcher.GetJobs(ctx)
@@ -120,6 +135,9 @@ func (r *queryResolver) Jobs(ctx context.Context) ([]*model.Job, error) {
 
 	return model.Map(dbJobs, model.FromStorageJob), nil
 }
+
+// Incident returns IncidentResolver implementation.
+func (r *Resolver) Incident() IncidentResolver { return &incidentResolver{r} }
 
 // Instance returns InstanceResolver implementation.
 func (r *Resolver) Instance() InstanceResolver { return &instanceResolver{r} }
@@ -133,6 +151,7 @@ func (r *Resolver) Process() ProcessResolver { return &processResolver{r} }
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
+type incidentResolver struct{ *Resolver }
 type instanceResolver struct{ *Resolver }
 type jobResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }

--- a/backend/internal/storage/fetch.go
+++ b/backend/internal/storage/fetch.go
@@ -114,6 +114,29 @@ func (f *Fetcher) GetJobsForInstance(ctx context.Context, instanceKey int64) ([]
 	return jobs, err
 }
 
+// Gets all incidents.
+func (f *Fetcher) GetIncidents(ctx context.Context) ([]Incident, error) {
+	var incidents []Incident
+	err := f.ContextDB(ctx).
+		Order("time DESC").
+		Find(&incidents).
+		Error
+
+	return incidents, err
+}
+
+// Gets all incidents for an instance.
+func (f *Fetcher) GetIncidentsForInstance(ctx context.Context, instanceKey int64) ([]Incident, error) {
+	var incidents []Incident
+	err := f.ContextDB(ctx).
+		Where(&Incident{ProcessInstanceKey: instanceKey}).
+		Order("time DESC").
+		Find(&incidents).
+		Error
+
+	return incidents, err
+}
+
 // Gets all variables for an instance.
 func (f *Fetcher) GetVariablesForInstance(ctx context.Context, instanceKey int64) ([]Variable, error) {
 	var variables []Variable

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -62,6 +62,33 @@ var expectedJobs = []Job{
 	},
 }
 
+var expectedIncidents = []Incident{
+	{
+		Key:                1,
+		ProcessInstanceKey: 10,
+		ElementID:          "element-1",
+		ErrorType:          "error-type-1",
+		ErrorMessage:       "error-message-1",
+		State:              "state-1",
+	},
+	{
+		Key:                2,
+		ProcessInstanceKey: 20,
+		ElementID:          "element-2",
+		ErrorType:          "error-type-2",
+		ErrorMessage:       "error-message-2",
+		State:              "state-2",
+	},
+	{
+		Key:                3,
+		ProcessInstanceKey: 20,
+		ElementID:          "element-3",
+		ErrorType:          "error-type-3",
+		ErrorMessage:       "error-message-3",
+		State:              "state-3",
+	},
+}
+
 func TestBpmnResourceQuery(t *testing.T) {
 	testDb := newMigratedTestDB(t)
 	defer func() {
@@ -354,6 +381,75 @@ func TestJobsForInstanceQuery(t *testing.T) {
 			assert.Len(t, jobs, len(test.jobs))
 			for i := range jobs {
 				assert.Equal(t, test.jobs[i], jobs[i])
+			}
+		})
+	}
+}
+
+func TestIncidentsQuery(t *testing.T) {
+	testDb := newMigratedTestDB(t)
+	defer func() {
+		assert.NoError(t, testDb.Rollback())
+	}()
+	db := testDb.DB()
+
+	fetcher := NewFetcher(db)
+
+	err := db.Create(expectedIncidents).Error
+	assert.NoError(t, err)
+
+	incidents, err := fetcher.GetIncidents(context.Background())
+	assert.NoError(t, err)
+
+	assert.Len(t, incidents, len(expectedIncidents))
+	for i := range incidents {
+		assert.Equal(t, expectedIncidents[i], incidents[i])
+	}
+}
+
+func TestIncidentsForInstanceQuery(t *testing.T) {
+	testDb := newMigratedTestDB(t)
+	defer func() {
+		assert.NoError(t, testDb.Rollback())
+	}()
+
+	fetcher := NewFetcher(testDb.DB())
+
+	err := testDb.DB().Create(expectedIncidents).Error
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		instanceKey int64
+		incidents   []Incident
+	}{
+		{
+			name:        "instance with one incidents",
+			instanceKey: 10,
+			incidents:   expectedIncidents[:1],
+		},
+		{
+			name:        "instance with two incidents",
+			instanceKey: 20,
+			incidents:   expectedIncidents[1:3],
+		},
+		{
+			name:        "instance with no incidents",
+			instanceKey: 30,
+			incidents:   []Incident{},
+		},
+	}
+
+	for _, test := range tests {
+		// Capture range variable.
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			incidents, err := fetcher.GetIncidentsForInstance(context.Background(), test.instanceKey)
+			assert.NoError(t, err)
+
+			assert.Len(t, incidents, len(test.incidents))
+			for i := range incidents {
+				assert.Equal(t, test.incidents[i], incidents[i])
 			}
 		})
 	}

--- a/backend/internal/storage/fetch_test.go
+++ b/backend/internal/storage/fetch_test.go
@@ -424,7 +424,7 @@ func TestIncidentsForInstanceQuery(t *testing.T) {
 		incidents   []Incident
 	}{
 		{
-			name:        "instance with one incidents",
+			name:        "instance with one incident",
 			instanceKey: 10,
 			incidents:   expectedIncidents[:1],
 		},

--- a/backend/internal/storage/table.go
+++ b/backend/internal/storage/table.go
@@ -9,6 +9,7 @@ import (
 var TableMigrations = []any{
 	&Process{},
 	&Instance{},
+	&Incident{},
 	&Job{},
 	&Variable{},
 	&BpmnResource{},
@@ -22,6 +23,7 @@ type Instance struct {
 	Status               string    `gorm:"not null"`
 	StartTime            time.Time `gorm:"not null"`
 	EndTime              sql.NullTime
+	Incidents            []Incident `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 	Jobs                 []Job      `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 	Variables            []Variable `gorm:"foreignKey:ProcessInstanceKey;references:ProcessInstanceKey"`
 }
@@ -34,6 +36,16 @@ type Process struct {
 	DeploymentTime       time.Time    `gorm:"not null"`
 	BpmnResource         BpmnResource `gorm:"foreignKey:BpmnProcessID;references:BpmnProcessID"`
 	Instances            []Instance   `gorm:"foreignKey:ProcessDefinitionKey;references:ProcessDefinitionKey"`
+}
+
+type Incident struct {
+	Key                int64     `gorm:"primarykey"`
+	ProcessInstanceKey int64     `gorm:"not null"`
+	ElementID          string    `gorm:"not null"`
+	ErrorType          string    `gorm:"not null"`
+	ErrorMessage       string    `gorm:"not null"`
+	State              string    `gorm:"not null"`
+	Time               time.Time `gorm:"not null"`
 }
 
 // Job model struct for the 'jobs' database table.

--- a/backend/test/data/fill_db.sql
+++ b/backend/test/data/fill_db.sql
@@ -16,6 +16,26 @@ VALUES(11, 'a', '1', '2023-11-27T02:05:00Z');
 INSERT INTO variables(process_instance_key, name, value, time)
 VALUES(11, 'b', '2', '2023-11-27T02:22:00Z');
 
+INSERT INTO incidents(process_instance_key, element_id, key, error_type, error_message, state, time)
+VALUES(11, 'some-element-1', 100, 'ERROR', 'panic: runtime error: index out of range [4] with length 4
+
+goroutine 1 [running]:
+main.validateInput(0xc00001e1e0, 0x4, 0x4, 0x0, 0x0)
+    /path/to/validate.go:29 +0x1a2
+main.processData(0xc00001e1e0, 0x4, 0x4, 0x0)
+    /path/to/process.go:56 +0xef
+main.aggregateData(0x1139ba0, 0xc000010030, 0x3, 0x3)
+    /path/to/aggregate.go:42 +0x9c
+main.loadData(0x1139ba0, 0x1185b40, 0x1)
+    /path/to/load.go:37 +0x5a
+main.setupEnvironment()
+    /path/to/setup.go:24 +0x87
+main.init.0()
+    /path/to/main.go:18 +0x29
+', 'OPEN', '2023-11-27T02:23:00Z');
+INSERT INTO incidents(process_instance_key, element_id, key, error_type, error_message, state, time)
+VALUES(11, 'some-element-2', 101, 'ERROR', 'Thing not work', 'RESOLVED', '2023-11-27T02:24:00Z');
+
 INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, state, time)
 VALUES(11, 'some-element-1', 100, 'big-job', 4, 'big-boy-1', 'WORKING', '2023-11-27T02:23:00Z');
 INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, state, time)
@@ -32,6 +52,44 @@ INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, s
 VALUES(12, 'some-element-12', 200, 'small-job', 10, 'big-boy-1', 'WORKING', '2023-11-27T02:23:00Z');
 INSERT INTO jobs(process_instance_key, element_id, key, type, retries, worker, state, time)
 VALUES(12, 'some-element-22', 201, 'tiny-job', 2, 'big-boy-1', 'WORKING', '2023-11-27T02:24:00Z');
+
+INSERT INTO incidents(process_instance_key, element_id, key, error_type, error_message, state, time)
+VALUES(12, 'some-element-3', 102, 'ERROR', 'panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10d3c7b]
+
+goroutine 1 [running]:
+main.computeStatistics(0x0)
+    /path/to/statistics.go:87 +0x3b
+main.validateInput(0x0)
+    /path/to/validate.go:29 +0x1a2
+main.preprocessData(0x0)
+    /path/to/preprocess.go:73 +0xbf
+main.processData(0x0)
+    /path/to/process.go:56 +0xef
+main.aggregateData(0x1139ba0, 0x0, 0x0, 0x0)
+    /path/to/aggregate.go:42 +0x9c
+main.loadData(0x1139ba0, 0x0)
+    /path/to/load.go:37 +0x5a
+main.setupEnvironment()
+    /path/to/setup.go:24 +0x87
+main.initConfig()
+    /path/to/config.go:58 +0x104
+main.checkDependencies()
+    /path/to/dependencies.go:15 +0x79
+main.initializeLogger()
+    /path/to/logger.go:28 +0x45
+main.connectToDatabase(0x113f2c0, 0x0)
+    /path/to/database.go:19 +0x9f
+main.verifyUserCredentials(0x0, 0x0)
+    /path/to/authentication.go:34 +0x153
+main.sessionStart(0x1138be0, 0x0, 0x0)
+    /path/to/session.go:21 +0x8a
+main.init.1()
+    /path/to/main.go:26 +0x34
+main.init.0()
+    /path/to/main.go:18 +0x29
+', 'OPEN', '2023-11-27T02:33:00Z');
+
 --------------------------------------------------------------------------------------------------------------
 
 INSERT INTO processes(process_definition_key, bpmn_process_id, version, deployment_time)


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#146
Closes ducanhpham0312/zeevision-private#8

### Description
<!-- Please add what is included in this pull request. -->
Added incidents table and query paths for all incidents and instance specific incidents. It also possible to reverse search instance of any incident.

I ended up adding `instanceKey` to incidents to allow instance query.

### Testing
<!-- How can code reviewers test this PR? -->
- Start test bench
- Wipe old volume with `docker compose down --volumes`
- Start zeevision
- Use `fill_db.sql` to fill database from pgAdmin
- Use API playground to validate incident query works for total of three incidents, where two are associated with instance `11` and one is with instance `12`.