### PR TITLE
fix: version column for processes page

### DIFF
--- a/frontend/src/hooks/useQueryProcesses.ts
+++ b/frontend/src/hooks/useQueryProcesses.ts
@@ -10,6 +10,7 @@ const PROCESSES_QUERY = () => gql`
     processes {
       bpmnProcessId
       processKey
+      version
       deploymentTime
       instances {
         version

--- a/frontend/src/pages/ProcessesPage.tsx
+++ b/frontend/src/pages/ProcessesPage.tsx
@@ -28,7 +28,7 @@ export default function ProcessesPage() {
         </div>
         <Table
           alterRowColor
-          header={["Process Key", "Process ID", "Deployment Time"]}
+          header={["Process Key", "Process ID", "Version", "Deployment Time"]}
           orientation="horizontal"
           expandElement={(idx: number) => (
             <div className="flex flex-col gap-4 p-4">
@@ -61,9 +61,10 @@ export default function ProcessesPage() {
           content={
             processes
               ? processes.map(
-                  ({ processKey, bpmnProcessId, deploymentTime }) => [
+                  ({ processKey, bpmnProcessId, version, deploymentTime }) => [
                     <NavLink to={processKey.toString()}>{processKey}</NavLink>,
                     bpmnProcessId,
+                    version,
                     deploymentTime,
                   ],
                 )


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Relates to ducanhpham0312/zeevision-private#135, but for the frontend.


### Description
<!-- Please add what is included in this pull request. -->
After #264, the processes page can now display multiple BPMNs with the same process ID but different version. This PR add the version column to processes page. 

### Testing
<!-- How can code reviewers test this PR? -->
- Only test this after #264 is merged. Then merge `master` to this branch.
- Run test-bench and the application
- Deploy any process. It should be visible on the ProcessesPage with Version 1
- Edit the `.bpmn` file of the deployed process and deploy it again. Another process should bevisible, with the same process ID but version 2.