### PR TITLE
refactor: remove Status enum

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -1346,9 +1346,9 @@ func (ec *executionContext) _Instance_status(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.(model.Status)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1358,7 +1358,7 @@ func (ec *executionContext) fieldContext_Instance_status(ctx context.Context, fi
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Status does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6278,16 +6278,6 @@ func (ec *executionContext) marshalNProcess2ᚖgithubᚗcomᚋducanhpham0312ᚋz
 		return graphql.Null
 	}
 	return ec._Process(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx context.Context, v interface{}) (model.Status, error) {
-	var res model.Status
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNStatus2githubᚗcomᚋducanhpham0312ᚋzeevisionᚋbackendᚋgraphᚋmodelᚐStatus(ctx context.Context, sel ast.SelectionSet, v model.Status) graphql.Marshaler {
-	return v
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/ducanhpham0312/zeevision/backend/internal/storage"
@@ -28,12 +27,6 @@ func FromStorageBpmnResource(bpmnResource storage.BpmnResource) string {
 
 // Convert storage instance to GraphQL instance.
 func FromStorageInstance(instance storage.Instance) *Instance {
-	var status Status
-	if err := status.UnmarshalGQL(instance.Status); err != nil {
-		// Panic will be caught by the GraphQL server as internal server error.
-		panic(fmt.Errorf("unmarshal storage instance: %w", err))
-	}
-
 	return &Instance{
 		BpmnLiveStatus: "", // TODO
 		StartTime:      formatTime(instance.StartTime),
@@ -41,7 +34,7 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 		InstanceKey:    instance.ProcessInstanceKey,
 		ProcessKey:     instance.ProcessDefinitionKey,
 		Version:        instance.Version,
-		Status:         status,
+		Status:         instance.Status,
 		// Variables and Process have their own resolvers and are not populated
 		// here.
 	}

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -57,7 +57,7 @@ func TestFromStorageInstance(t *testing.T) {
 				InstanceKey:    10,
 				ProcessKey:     1,
 				Version:        1,
-				Status:         StatusActive,
+				Status:         "ACTIVE",
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestFromStorageInstance(t *testing.T) {
 				InstanceKey:    20,
 				ProcessKey:     2,
 				Version:        2,
-				Status:         StatusCompleted,
+				Status:         "COMPLETED",
 			},
 		},
 	}
@@ -89,69 +89,6 @@ func TestFromStorageInstance(t *testing.T) {
 			assert.Equal(t, test.expected, actual)
 		})
 	}
-}
-
-func TestStatus(t *testing.T) {
-	tests := []struct {
-		name        string
-		status      any
-		expectedErr string
-		expected    Status
-	}{
-		{
-			name:     "Active",
-			status:   "ACTIVE",
-			expected: StatusActive,
-		},
-		{
-			name:     "Completed",
-			status:   "COMPLETED",
-			expected: StatusCompleted,
-		},
-		{
-			name:     "Terminated",
-			status:   "TERMINATED",
-			expected: StatusTerminated,
-		},
-		{
-			name:        "Invalid status",
-			status:      "INVALID_STATUS",
-			expectedErr: "INVALID_STATUS is not a valid Status",
-		},
-		{
-			name:        "Invalid type",
-			status:      1,
-			expectedErr: "enums must be strings",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var actual Status
-			err := actual.UnmarshalGQL(test.status)
-			if test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
-				return
-			}
-
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestStorageInstanceConversionPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			assert.Fail(t, "expected panic")
-		}
-	}()
-
-	storageInstance := storage.Instance{
-		Status: "INVALID_STATUS",
-	}
-
-	// Should panic.
-	FromStorageInstance(storageInstance)
 }
 
 func TestFromStorageProcess(t *testing.T) {

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -2,12 +2,6 @@
 
 package model
 
-import (
-	"fmt"
-	"io"
-	"strconv"
-)
-
 type Incident struct {
 	IncidentKey  int64     `json:"incidentKey"`
 	InstanceKey  int64     `json:"instanceKey"`
@@ -26,7 +20,7 @@ type Instance struct {
 	InstanceKey    int64       `json:"instanceKey"`
 	ProcessKey     int64       `json:"processKey"`
 	Version        int64       `json:"version"`
-	Status         Status      `json:"status"`
+	Status         string      `json:"status"`
 	Incidents      []*Incident `json:"incidents"`
 	Jobs           []*Job      `json:"jobs"`
 	Variables      []*Variable `json:"variables"`
@@ -61,47 +55,4 @@ type Variable struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 	Time  string `json:"time"`
-}
-
-type Status string
-
-const (
-	StatusActive     Status = "ACTIVE"
-	StatusCompleted  Status = "COMPLETED"
-	StatusTerminated Status = "TERMINATED"
-)
-
-var AllStatus = []Status{
-	StatusActive,
-	StatusCompleted,
-	StatusTerminated,
-}
-
-func (e Status) IsValid() bool {
-	switch e {
-	case StatusActive, StatusCompleted, StatusTerminated:
-		return true
-	}
-	return false
-}
-
-func (e Status) String() string {
-	return string(e)
-}
-
-func (e *Status) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = Status(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid Status", str)
-	}
-	return nil
-}
-
-func (e Status) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -37,7 +37,7 @@ type Instance {
   instanceKey: Int!
   processKey: Int!
   version: Int!
-  status: Status!
+  status: String!
   incidents: [Incident!]! @goField(forceResolver: true)
   jobs: [Job!]! @goField(forceResolver: true)
   variables: [Variable!]! @goField(forceResolver: true)
@@ -71,12 +71,6 @@ type Variable {
   name: String!
   value: String!
   time: DateTime!
-}
-
-enum Status {
-  ACTIVE
-  COMPLETED
-  TERMINATED
 }
 
 # The `DateTime` scalar type represents a date and time following the


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
Closes ducanhpham0312/zeevision-private#152


### Description
<!-- Please add what is included in this pull request. -->
Removed `Status` enum used for `status` field in instances since it didn't provide any help in development, and caused internal system errors.

### Testing
<!-- How can code reviewers test this PR? -->
- Test that Instance statuses are shown correctly and as previously.