### PR TITLE
chore: group swc in dependabot upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
           - "eslint"
           - "eslint-*"
           - "@typescript-eslint/*"
+          - "@swc/*"
     open-pull-requests-limit: 10
     labels:
       - "dependabot"


### PR DESCRIPTION

### Description
<!-- Please add what is included in this pull request. -->
- Multiple #swc libraries has been added recently to make the frontend run properly on linux env. This PR allows those libraries to be upgraded in one PR.