### PR TITLE
fix: use format with milliseconds for timestamps

### DIFF
--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -126,9 +126,13 @@ func ToStoragePagination(pagination *Pagination) *storage.Pagination {
 	}
 }
 
+// Custom format since it's not found in the time module.
+// Time in RFC3339 format, but with milliseconds (including zero digits)
+const RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
+
 // Convert time to RFC3339 format.
 func formatTime(t time.Time) string {
-	return t.UTC().Format(time.RFC3339)
+	return t.UTC().Format(RFC3339Milli)
 }
 
 // Convert nullable time to RFC3339 format. Null times are converted to nil.

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -33,7 +33,7 @@ func TestFromStorageBpmnResource(t *testing.T) {
 
 func TestFromStorageInstance(t *testing.T) {
 	now := time.Now()
-	nowFormatted := now.UTC().Format(time.RFC3339)
+	nowFormatted := now.UTC().Format(RFC3339Milli)
 
 	tests := []struct {
 		name            string
@@ -125,7 +125,7 @@ func TestFromStorageProcess(t *testing.T) {
 				ActiveInstances:    0,  // TODO
 				CompletedInstances: 0,  // TODO
 				BpmnLiveStatus:     "", // TODO
-				DeploymentTime:     now.UTC().Format(time.RFC3339),
+				DeploymentTime:     now.UTC().Format(RFC3339Milli),
 				BpmnProcessID:      "main-loop",
 				BpmnResource:       "",
 				ProcessKey:         1,
@@ -151,7 +151,7 @@ func TestFromStorageProcess(t *testing.T) {
 				ActiveInstances:    0,  // TODO
 				CompletedInstances: 0,  // TODO
 				BpmnLiveStatus:     "", // TODO
-				DeploymentTime:     now.UTC().Format(time.RFC3339),
+				DeploymentTime:     now.UTC().Format(RFC3339Milli),
 				BpmnProcessID:      "main-loop",
 				BpmnResource:       "",
 				ProcessKey:         2,
@@ -185,7 +185,7 @@ func TestFromStorageAuditLog(t *testing.T) {
 		ElementType: "element-type",
 		Intent:      "intent",
 		Position:    10,
-		Time:        now.UTC().Format(time.RFC3339),
+		Time:        now.UTC().Format(RFC3339Milli),
 	}
 
 	actual := FromStorageAuditLog(storageAuditLog)
@@ -212,7 +212,7 @@ func TestFromStrorageIncident(t *testing.T) {
 		ErrorType:    "error-type",
 		ErrorMessage: "error-message",
 		State:        "state",
-		Time:         now.UTC().Format(time.RFC3339),
+		Time:         now.UTC().Format(RFC3339Milli),
 	}
 
 	actual := FromStorageIncident(storageIncident)
@@ -240,7 +240,7 @@ func TestFromStorageJob(t *testing.T) {
 		Retries:     3,
 		Worker:      "worker",
 		State:       "state",
-		Time:        now.UTC().Format(time.RFC3339),
+		Time:        now.UTC().Format(RFC3339Milli),
 		InstanceKey: 100,
 	}
 
@@ -261,7 +261,7 @@ func TestFromStorageVariable(t *testing.T) {
 	expected := &Variable{
 		Name:  "variable-name",
 		Value: "variable-value",
-		Time:  now.UTC().Format(time.RFC3339),
+		Time:  now.UTC().Format(RFC3339Milli),
 	}
 
 	actual := FromStorageVariable(storageVariable)


### PR DESCRIPTION

### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
None

### Description
<!-- Please add what is included in this pull request. -->
This is also what ZSM does. This format is not exposed by the time module so add our own constant for it as well.

### Testing
<!-- How can code reviewers test this PR? -->
- Launch zeevision
- Ensure something with a timestamp is stored in the zeevision database (load test data, deploy process, etc.)
- The timestamp should include milliseconds