### PR TITLE
refactor(backend): remove unused API variables

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -70,18 +70,17 @@ type ComplexityRoot struct {
 	}
 
 	Instance struct {
-		AuditLogs      func(childComplexity int, pagination *model.Pagination) int
-		BpmnLiveStatus func(childComplexity int) int
-		EndTime        func(childComplexity int) int
-		Incidents      func(childComplexity int, pagination *model.Pagination) int
-		InstanceKey    func(childComplexity int) int
-		Jobs           func(childComplexity int, pagination *model.Pagination) int
-		Process        func(childComplexity int) int
-		ProcessKey     func(childComplexity int) int
-		StartTime      func(childComplexity int) int
-		Status         func(childComplexity int) int
-		Variables      func(childComplexity int, pagination *model.Pagination, filter *model.VariableFilter) int
-		Version        func(childComplexity int) int
+		AuditLogs   func(childComplexity int, pagination *model.Pagination) int
+		EndTime     func(childComplexity int) int
+		Incidents   func(childComplexity int, pagination *model.Pagination) int
+		InstanceKey func(childComplexity int) int
+		Jobs        func(childComplexity int, pagination *model.Pagination) int
+		Process     func(childComplexity int) int
+		ProcessKey  func(childComplexity int) int
+		StartTime   func(childComplexity int) int
+		Status      func(childComplexity int) int
+		Variables   func(childComplexity int, pagination *model.Pagination, filter *model.VariableFilter) int
+		Version     func(childComplexity int) int
 	}
 
 	Job struct {
@@ -127,15 +126,12 @@ type ComplexityRoot struct {
 	}
 
 	Process struct {
-		ActiveInstances    func(childComplexity int) int
-		BpmnLiveStatus     func(childComplexity int) int
-		BpmnProcessID      func(childComplexity int) int
-		BpmnResource       func(childComplexity int) int
-		CompletedInstances func(childComplexity int) int
-		DeploymentTime     func(childComplexity int) int
-		Instances          func(childComplexity int, pagination *model.Pagination) int
-		ProcessKey         func(childComplexity int) int
-		Version            func(childComplexity int) int
+		BpmnProcessID  func(childComplexity int) int
+		BpmnResource   func(childComplexity int) int
+		DeploymentTime func(childComplexity int) int
+		Instances      func(childComplexity int, pagination *model.Pagination) int
+		ProcessKey     func(childComplexity int) int
+		Version        func(childComplexity int) int
 	}
 
 	Query struct {
@@ -302,13 +298,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Instance.AuditLogs(childComplexity, args["pagination"].(*model.Pagination)), true
-
-	case "Instance.bpmnLiveStatus":
-		if e.complexity.Instance.BpmnLiveStatus == nil {
-			break
-		}
-
-		return e.complexity.Instance.BpmnLiveStatus(childComplexity), true
 
 	case "Instance.endTime":
 		if e.complexity.Instance.EndTime == nil {
@@ -542,20 +531,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PaginatedVariables.TotalCount(childComplexity), true
 
-	case "Process.activeInstances":
-		if e.complexity.Process.ActiveInstances == nil {
-			break
-		}
-
-		return e.complexity.Process.ActiveInstances(childComplexity), true
-
-	case "Process.bpmnLiveStatus":
-		if e.complexity.Process.BpmnLiveStatus == nil {
-			break
-		}
-
-		return e.complexity.Process.BpmnLiveStatus(childComplexity), true
-
 	case "Process.bpmnProcessId":
 		if e.complexity.Process.BpmnProcessID == nil {
 			break
@@ -569,13 +544,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Process.BpmnResource(childComplexity), true
-
-	case "Process.completedInstances":
-		if e.complexity.Process.CompletedInstances == nil {
-			break
-		}
-
-		return e.complexity.Process.CompletedInstances(childComplexity), true
 
 	case "Process.deploymentTime":
 		if e.complexity.Process.DeploymentTime == nil {
@@ -1608,8 +1576,6 @@ func (ec *executionContext) fieldContext_Incident_instance(ctx context.Context, 
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
 			case "endTime":
@@ -1634,50 +1600,6 @@ func (ec *executionContext) fieldContext_Incident_instance(ctx context.Context, 
 				return ec.fieldContext_Instance_process(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Instance", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Instance_bpmnLiveStatus(ctx context.Context, field graphql.CollectedField, obj *model.Instance) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnLiveStatus, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Instance_bpmnLiveStatus(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Instance",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -2227,12 +2149,6 @@ func (ec *executionContext) fieldContext_Instance_process(ctx context.Context, f
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "activeInstances":
-				return ec.fieldContext_Process_activeInstances(ctx, field)
-			case "completedInstances":
-				return ec.fieldContext_Process_completedInstances(ctx, field)
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
 			case "bpmnResource":
 				return ec.fieldContext_Process_bpmnResource(ctx, field)
 			case "bpmnProcessId":
@@ -2643,8 +2559,6 @@ func (ec *executionContext) fieldContext_Job_instance(ctx context.Context, field
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
 			case "endTime":
@@ -2919,8 +2833,6 @@ func (ec *executionContext) fieldContext_PaginatedInstances_items(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
 			case "endTime":
@@ -3141,12 +3053,6 @@ func (ec *executionContext) fieldContext_PaginatedProcesses_items(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "activeInstances":
-				return ec.fieldContext_Process_activeInstances(ctx, field)
-			case "completedInstances":
-				return ec.fieldContext_Process_completedInstances(ctx, field)
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
 			case "bpmnResource":
 				return ec.fieldContext_Process_bpmnResource(ctx, field)
 			case "bpmnProcessId":
@@ -3301,138 +3207,6 @@ func (ec *executionContext) fieldContext_PaginatedVariables_totalCount(ctx conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Process_activeInstances(ctx context.Context, field graphql.CollectedField, obj *model.Process) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Process_activeInstances(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ActiveInstances, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int64)
-	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Process_activeInstances(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Process",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Process_completedInstances(ctx context.Context, field graphql.CollectedField, obj *model.Process) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Process_completedInstances(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.CompletedInstances, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int64)
-	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Process_completedInstances(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Process",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Process_bpmnLiveStatus(ctx context.Context, field graphql.CollectedField, obj *model.Process) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BpmnLiveStatus, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Process_bpmnLiveStatus(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Process",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3816,12 +3590,6 @@ func (ec *executionContext) fieldContext_Query_process(ctx context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "activeInstances":
-				return ec.fieldContext_Process_activeInstances(ctx, field)
-			case "completedInstances":
-				return ec.fieldContext_Process_completedInstances(ctx, field)
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Process_bpmnLiveStatus(ctx, field)
 			case "bpmnResource":
 				return ec.fieldContext_Process_bpmnResource(ctx, field)
 			case "bpmnProcessId":
@@ -3949,8 +3717,6 @@ func (ec *executionContext) fieldContext_Query_instance(ctx context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "bpmnLiveStatus":
-				return ec.fieldContext_Instance_bpmnLiveStatus(ctx, field)
 			case "startTime":
 				return ec.fieldContext_Instance_startTime(ctx, field)
 			case "endTime":
@@ -6398,11 +6164,6 @@ func (ec *executionContext) _Instance(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Instance")
-		case "bpmnLiveStatus":
-			out.Values[i] = ec._Instance_bpmnLiveStatus(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "startTime":
 			out.Values[i] = ec._Instance_startTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -7018,21 +6779,6 @@ func (ec *executionContext) _Process(ctx context.Context, sel ast.SelectionSet, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Process")
-		case "activeInstances":
-			out.Values[i] = ec._Process_activeInstances(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "completedInstances":
-			out.Values[i] = ec._Process_completedInstances(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "bpmnLiveStatus":
-			out.Values[i] = ec._Process_bpmnLiveStatus(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "bpmnResource":
 			field := field
 

--- a/backend/graph/model/convert.go
+++ b/backend/graph/model/convert.go
@@ -28,13 +28,12 @@ func FromStorageBpmnResource(bpmnResource storage.BpmnResource) string {
 // Convert storage instance to GraphQL instance.
 func FromStorageInstance(instance storage.Instance) *Instance {
 	return &Instance{
-		BpmnLiveStatus: "", // TODO
-		StartTime:      formatTime(instance.StartTime),
-		EndTime:        formatNullTime(instance.EndTime),
-		InstanceKey:    instance.ProcessInstanceKey,
-		ProcessKey:     instance.ProcessDefinitionKey,
-		Version:        instance.Version,
-		Status:         instance.Status,
+		StartTime:   formatTime(instance.StartTime),
+		EndTime:     formatNullTime(instance.EndTime),
+		InstanceKey: instance.ProcessInstanceKey,
+		ProcessKey:  instance.ProcessDefinitionKey,
+		Version:     instance.Version,
+		Status:      instance.Status,
 		// Variables and Process have their own resolvers and are not populated
 		// here.
 	}
@@ -43,13 +42,10 @@ func FromStorageInstance(instance storage.Instance) *Instance {
 // Convert storage process to GraphQL process.
 func FromStorageProcess(process storage.Process) *Process {
 	return &Process{
-		ActiveInstances:    0,  // TODO
-		CompletedInstances: 0,  // TODO
-		BpmnLiveStatus:     "", // TODO
-		BpmnProcessID:      process.BpmnProcessID,
-		DeploymentTime:     formatTime(process.DeploymentTime),
-		ProcessKey:         process.ProcessDefinitionKey,
-		Version:            process.Version,
+		BpmnProcessID:  process.BpmnProcessID,
+		DeploymentTime: formatTime(process.DeploymentTime),
+		ProcessKey:     process.ProcessDefinitionKey,
+		Version:        process.Version,
 		// Instances, MessageSubscriptions, Timers, BpmnResource have their
 		// own resolvers and are not populated here.
 	}

--- a/backend/graph/model/convert_test.go
+++ b/backend/graph/model/convert_test.go
@@ -51,13 +51,12 @@ func TestFromStorageInstance(t *testing.T) {
 				EndTime:              sql.NullTime{},
 			},
 			expected: &Instance{
-				BpmnLiveStatus: "", // TODO
-				StartTime:      nowFormatted,
-				EndTime:        nil,
-				InstanceKey:    10,
-				ProcessKey:     1,
-				Version:        1,
-				Status:         "ACTIVE",
+				StartTime:   nowFormatted,
+				EndTime:     nil,
+				InstanceKey: 10,
+				ProcessKey:  1,
+				Version:     1,
+				Status:      "ACTIVE",
 			},
 		},
 		{
@@ -71,13 +70,12 @@ func TestFromStorageInstance(t *testing.T) {
 				EndTime:              sql.NullTime{Time: now, Valid: true},
 			},
 			expected: &Instance{
-				BpmnLiveStatus: "", // TODO
-				StartTime:      nowFormatted,
-				EndTime:        &nowFormatted,
-				InstanceKey:    20,
-				ProcessKey:     2,
-				Version:        2,
-				Status:         "COMPLETED",
+				StartTime:   nowFormatted,
+				EndTime:     &nowFormatted,
+				InstanceKey: 20,
+				ProcessKey:  2,
+				Version:     2,
+				Status:      "COMPLETED",
 			},
 		},
 	}
@@ -122,14 +120,11 @@ func TestFromStorageProcess(t *testing.T) {
 				},
 			},
 			expected: &Process{
-				ActiveInstances:    0,  // TODO
-				CompletedInstances: 0,  // TODO
-				BpmnLiveStatus:     "", // TODO
-				DeploymentTime:     now.UTC().Format(RFC3339Milli),
-				BpmnProcessID:      "main-loop",
-				BpmnResource:       "",
-				ProcessKey:         1,
-				Version:            1,
+				DeploymentTime: now.UTC().Format(RFC3339Milli),
+				BpmnProcessID:  "main-loop",
+				BpmnResource:   "",
+				ProcessKey:     1,
+				Version:        1,
 			},
 		},
 		{
@@ -148,14 +143,11 @@ func TestFromStorageProcess(t *testing.T) {
 				Instances: []storage.Instance{},
 			},
 			expected: &Process{
-				ActiveInstances:    0,  // TODO
-				CompletedInstances: 0,  // TODO
-				BpmnLiveStatus:     "", // TODO
-				DeploymentTime:     now.UTC().Format(RFC3339Milli),
-				BpmnProcessID:      "main-loop",
-				BpmnResource:       "",
-				ProcessKey:         2,
-				Version:            1,
+				DeploymentTime: now.UTC().Format(RFC3339Milli),
+				BpmnProcessID:  "main-loop",
+				BpmnResource:   "",
+				ProcessKey:     2,
+				Version:        1,
 			},
 		},
 	}

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -28,18 +28,17 @@ type Incident struct {
 }
 
 type Instance struct {
-	BpmnLiveStatus string              `json:"bpmnLiveStatus"`
-	StartTime      string              `json:"startTime"`
-	EndTime        *string             `json:"endTime,omitempty"`
-	InstanceKey    int64               `json:"instanceKey"`
-	ProcessKey     int64               `json:"processKey"`
-	Version        int64               `json:"version"`
-	Status         string              `json:"status"`
-	AuditLogs      *PaginatedAuditLogs `json:"auditLogs"`
-	Incidents      *PaginatedIncidents `json:"incidents"`
-	Jobs           *PaginatedJobs      `json:"jobs"`
-	Variables      *PaginatedVariables `json:"variables"`
-	Process        *Process            `json:"process"`
+	StartTime   string              `json:"startTime"`
+	EndTime     *string             `json:"endTime,omitempty"`
+	InstanceKey int64               `json:"instanceKey"`
+	ProcessKey  int64               `json:"processKey"`
+	Version     int64               `json:"version"`
+	Status      string              `json:"status"`
+	AuditLogs   *PaginatedAuditLogs `json:"auditLogs"`
+	Incidents   *PaginatedIncidents `json:"incidents"`
+	Jobs        *PaginatedJobs      `json:"jobs"`
+	Variables   *PaginatedVariables `json:"variables"`
+	Process     *Process            `json:"process"`
 }
 
 type Job struct {
@@ -90,15 +89,12 @@ type Pagination struct {
 }
 
 type Process struct {
-	ActiveInstances    int64               `json:"activeInstances"`
-	CompletedInstances int64               `json:"completedInstances"`
-	BpmnLiveStatus     string              `json:"bpmnLiveStatus"`
-	BpmnResource       string              `json:"bpmnResource"`
-	BpmnProcessID      string              `json:"bpmnProcessId"`
-	DeploymentTime     string              `json:"deploymentTime"`
-	Instances          *PaginatedInstances `json:"instances"`
-	ProcessKey         int64               `json:"processKey"`
-	Version            int64               `json:"version"`
+	BpmnResource   string              `json:"bpmnResource"`
+	BpmnProcessID  string              `json:"bpmnProcessId"`
+	DeploymentTime string              `json:"deploymentTime"`
+	Instances      *PaginatedInstances `json:"instances"`
+	ProcessKey     int64               `json:"processKey"`
+	Version        int64               `json:"version"`
 }
 
 type Variable struct {

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -40,9 +40,6 @@ type PaginatedProcesses {
 }
 
 type Process {
-  activeInstances: Int!
-  completedInstances: Int!
-  bpmnLiveStatus: String!
   bpmnResource: String! @goField(forceResolver: true)
   bpmnProcessId: String!
   deploymentTime: DateTime!
@@ -58,7 +55,6 @@ type PaginatedInstances {
 }
 
 type Instance {
-  bpmnLiveStatus: String!
   startTime: DateTime!
   endTime: DateTime
   instanceKey: Int!


### PR DESCRIPTION
### Linked issue
<!-- Please modify the your-issue-number below with your issue number written on the issue ticket. -->
None


### Description
<!-- Please add what is included in this pull request. -->
Removed `bpmnLiveStatus`, `activeInstances`, and `completedInstances` from API since they do not work and aren't used.

### Testing
<!-- How can code reviewers test this PR? -->
Verify through API playground that these variables cannot be queried.